### PR TITLE
Add a byte for null terminator

### DIFF
--- a/ESPHamClock/setup.cpp
+++ b/ESPHamClock/setup.cpp
@@ -4079,7 +4079,7 @@ static bool getWPACreds()
     }
 
     // look for ssid and psk
-    char buf[100], wpa_ssid[100], wpa_psk[100];
+    char buf[100], wpa_ssid[101], wpa_psk[101];
     bool found_ssid = false, found_psk = false;
     while (fgets (buf, sizeof(buf), wpa_fp)) {
         if (sscanf (buf, " ssid=\"%100[^\"]\"", wpa_ssid) == 1)


### PR DESCRIPTION
I guess android adds a -wfortify-source to the compile and a warning is generated. We might consider augmenting ESPHamClock's make but for now let's resolve this warning in the source.