### PR TITLE
A hardening flag recommend through Android

### DIFF
--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -13,7 +13,7 @@
 .PHONY: clean clobber help hclibs
 
 # build flags common to all options and architectures
-CXXFLAGS = -IArduinoLib -IwsServer/include -Izlib-hc -I. -g -O2 -Wall -pthread -std=c++17
+CXXFLAGS = -IArduinoLib -IwsServer/include -Izlib-hc -I. -g -O2 -Wall -pthread -std=c++17 -D_FORTIFY_SOURCE=2
 # CXXFLAGS += -Wextra -pedantic -Werror -Wno-attributes -Wno-unknown-pragmas
 
 # add explicit framebuffer depth as _FB_DEPTH if defined


### PR DESCRIPTION
While working on the android project, enabling the default hardening found a potential buffer overflow issue without room for a null terminatior. It seems like a good idea to add it to the base ESPHamClock project.