### PR TITLE
V4.31b05 beta fixes

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -2320,7 +2320,8 @@ extern bool checkOnTheAirTouch (TouchType tt, const SCoord &s, const SBox &box);
 // scripts' 65-minute window) -- polling much faster than that buys nothing, so this can
 // afford a longer client interval than ONTA_INTERVAL despite following the exact same
 // openCachedFile()-throttled pattern.
-#define BANDACT_INTERVAL   180                          // polling interval
+#define BANDACT_INTERVAL   60                           // polling interval -- also how often the
+                                                          // pane's "X m ago" freshness caption redraws
 
 extern bool updateBandActivity (const SBox &box, bool fresh);
 
@@ -3523,7 +3524,7 @@ extern void strncpySubChar (char to_str[], const char from_str[], char to_char, 
  *
  */
 
-void tooltip (const SCoord &s, const char *tip);
+void tooltip (const SCoord &s, const char *tip, const SBox *bound = NULL);
 
 
 

--- a/ESPHamClock/aprscluster.cpp
+++ b/ESPHamClock/aprscluster.cpp
@@ -1618,7 +1618,7 @@ bool checkAPRSClusterTouch (const SCoord &s, const SBox &box)
 
             if (s.x < dist_x) {
                 tooltip (s, "Stations heard nearby. Tap a row for full detail. Tap KM/MI to sort "
-                            "by distance or by time heard.");
+                            "by distance or by time heard.", &box);
                 return (true);
             }
 
@@ -1631,7 +1631,7 @@ bool checkAPRSClusterTouch (const SCoord &s, const SBox &box)
                 tooltip (s, aprs_sort_recent ? "Sorted by most recently heard. Tap KM/MI again to "
                                                 "sort by distance instead."
                                               : "Sorted by distance, nearest first. Tap KM/MI again "
-                                                "to sort by time heard instead.");
+                                                "to sort by time heard instead.", &box);
                 return (true);
             }
 
@@ -1642,14 +1642,14 @@ bool checkAPRSClusterTouch (const SCoord &s, const SBox &box)
                 tooltip (s, "Most APRS symbols show as small icons. \"-\" means either the "
                             "alternate symbol table (not decoded) or one of a handful of unused/"
                             "reserved primary-table codes. Tap KM/MI to sort by distance or by "
-                            "time heard.");
+                            "time heard.", &box);
                 return (true);
             }
 
             if (s.x >= age_x) {
                 tooltip (s, "Time since last heard: counts up in seconds, then switches to "
                             "whole minutes, hours, days, etc. Tap KM/MI to sort by distance or "
-                            "by time heard.");
+                            "by time heard.", &box);
                 return (true);
             }
         }
@@ -1673,7 +1673,7 @@ bool checkAPRSClusterTouch (const SCoord &s, const SBox &box)
 
             selectFontStyle (LIGHT_FONT, FAST_FONT);
             if (s.x < dist_x && getTextWidth (sp.call) > call_w) {
-                tooltip (s, sp.call);
+                tooltip (s, sp.call, &box);
                 return (true);
             }
 
@@ -1726,7 +1726,7 @@ bool checkAPRSClusterTouch (const SCoord &s, const SBox &box)
             } else {
                 snprintf (tip, sizeof(tip), "%s  position unknown  heard %s ago", sp.call, age);
             }
-            tooltip (s, tip);
+            tooltip (s, tip, &box);
             return (true);
         }
     }

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -1363,6 +1363,13 @@ void drawMoreEarth()
 
         // draw goodies unless showing CM_USER
         if (core_map != CM_USER) {
+            // country/state borders (Clouds/Terrain only) must be the lowest-Z overlay --
+            // draw them here, before the grid/sat-path/DX-path/PSK-path lines below, since
+            // those are painted directly on the just-swept map and NOT through drawAllSymbols()
+            // until a few lines later. Without this, drawAllSymbols()'s own (correctly early)
+            // drawCountryBorders() call would run *after* these and paint the border lines
+            // right over the satellite ground track/footprint, DX path and PSK paths.
+            drawCountryBorders();
             drawMapGrid();
             drawSatPathAndFoot();
             if (waiting4DXPath())

--- a/ESPHamClock/hamalert.cpp
+++ b/ESPHamClock/hamalert.cpp
@@ -431,7 +431,7 @@ bool updateHamAlert (const SBox &box, bool fresh)
         // and never even try, until a password (and optionally login) has actually been entered
         if (fresh)
             initHAGUI (box);
-        plotMessage (box, HAC_COLOR, "Set HamAlert User/Password in Setup pg 4");
+        plotMessage (box, HAC_COLOR, "Set HamAlert User/Password in Setup pg 7");
         return (false);
     }
 

--- a/ESPHamClock/ncdxf.cpp
+++ b/ESPHamClock/ncdxf.cpp
@@ -108,14 +108,47 @@ static void drawBeacon (NCDXFBeacon &nb)
     drawMapTag (nb.call, nb.call_b);
 }
 
+/* erase every beacon symbol and call sign tag from the map by restoring the underlying map
+ * pixels. called once, right when beacons transition from on to off, so they don't linger
+ * on screen until the next unrelated full map redraw happens to paint over them.
+ */
+static void eraseBeacons (void)
+{
+    for (NCDXFBeacon *bp = blist; bp < &blist[NBEACONS]; bp++) {
+        if (!overMap (bp->s))
+            continue;
+
+        // triangle symbol
+        SCircle sym_c;
+        sym_c.s = bp->s;
+        sym_c.r = BEACONR;
+        eraseSCircle (sym_c);
+
+        // call sign tag beneath it
+        for (uint16_t dy = 0; dy < bp->call_b.h; dy++)
+            for (uint16_t dx = 0; dx < bp->call_b.w; dx++)
+                drawMapCoord (bp->call_b.x + dx, bp->call_b.y + dy);
+    }
+}
+
 /* update map beacons, typically on each 10 second period unless immediate.
  */
 void updateBeacons (bool immediate)
 {
     // counts as on as long as in rotation set, need not be in front now
     bool beacons_on = brb_rotset & (1 << BRB_SHOW_BEACONS);
-    if (!beacons_on)
+
+    // if just turned off, erase immediately instead of leaving stale symbols on the map
+    // until whatever next unrelated event happens to trigger a full map redraw
+    static bool was_on;
+    if (!beacons_on) {
+        if (was_on) {
+            eraseBeacons();
+            was_on = false;
+        }
         return;
+    }
+    was_on = true;
 
     // process if immediate or it's a new time period
     static uint8_t prev_sec10;

--- a/ESPHamClock/ontheair.cpp
+++ b/ESPHamClock/ontheair.cpp
@@ -966,12 +966,20 @@ static void runONTASortMenu (const SBox &box)
 
     SBox menu_b = box;                          // copy, not ref!
     menu_b.y = box.y + 7;
-    if (!narrow && show_bio_enabled)
-        menu_b.y -= 11;                          // one row height (MENU_RH in menu.cpp, not
-                                                  // exported) -- 3-col layout is one row taller
-                                                  // with Bio shown (its row isn't removed the
-                                                  // way it is when Bio is off) -- shift up to
-                                                  // compensate so it doesn't overlap the pane
+    if (!narrow && show_bio_enabled) {
+        // one row height (MENU_RH in menu.cpp, not exported) -- 3-col layout is one row
+        // taller with Bio shown (its row isn't removed the way it is when Bio is off) --
+        // shift up to compensate so it doesn't overlap the pane.
+        // N.B. menu_b.y is unsigned: for a pane docked at the very top of the screen
+        // (box.y == 0, eg PANE_1/2/3), box.y+7 can be less than this 11px shift, so guard
+        // against underflow (which previously wrapped y to ~65535 and made runMenu()'s own
+        // off-screen repositioning logic shove the whole menu down to the bottom of the
+        // screen instead of over the pane -- the reported "menu opens at the bottom" bug).
+        if (menu_b.y >= 11)
+            menu_b.y -= 11;
+        else
+            menu_b.y = 0;
+    }
     if (narrow) {
         // 2-col layout has plenty of slack (~104px content in a 139px pane) -- a small
         // inset stays comfortably clear of the map without risking any auto-widen

--- a/ESPHamClock/tooltip.cpp
+++ b/ESPHamClock/tooltip.cpp
@@ -14,13 +14,26 @@
 
 /* show the given text in a box near the given location.
  * stay up until time out or any user input occurs.
+ * if bound is given, the tooltip is wrapped and positioned to stay entirely within it (eg the
+ * caller's own pane box) rather than being free to spill into neighboring panes -- see below.
  */
-void tooltip (const SCoord &s, const char *tip)
+void tooltip (const SCoord &s, const char *tip, const SBox *bound)
 {
     // save and restore font
     FontWeight fw;
     FontSize fs;
     getFontStyle (&fw, &fs);
+
+    // cap line length so the box fits within bound, if given -- otherwise TT_MAXLL is the only
+    // limit, same as always. N.B. this can only shrink max_ll, never grow it past TT_MAXLL.
+    int max_ll_cap = TT_MAXLL;
+    if (bound) {
+        int fit_ll = ((int)bound->w - 2*TT_BORDER) / TT_FONTW;
+        if (fit_ll < 1)
+            fit_ll = 1;                                 // pane is absurdly narrow -- still try
+        if (fit_ll < max_ll_cap)
+            max_ll_cap = fit_ll;
+    }
 
     // break into roughly same length lines at white space
     typedef struct {
@@ -28,7 +41,7 @@ void tooltip (const SCoord &s, const char *tip)
     } OneLine;
     OneLine tip_lines[TT_MAXLINES];                     // each line
     const size_t tip_len = strlen (tip);
-    int n_lines = tip_len / TT_MAXLL + 1;               // number of lines
+    int n_lines = tip_len / max_ll_cap + 1;             // number of lines
     int nom_ll = tip_len / n_lines;                     // nominal length of each line
     int max_ll = 0;                                     // actual longest line
 
@@ -38,8 +51,10 @@ void tooltip (const SCoord &s, const char *tip)
     for (int i = 0; i < n_lines; i++) {
         OneLine &ol = tip_lines[i];
         ol.start = start;
-        // find right-most blank after start + nom_ll. N.B. beware EOS on last line
-        for (ol.count = 0; tip[start+ol.count] != '\0'; ol.count++)
+        // find right-most blank after start + nom_ll, but never past max_ll_cap -- else, with no
+        // blank in range, a line could still run wider than bound allows. N.B. beware EOS on
+        // last line
+        for (ol.count = 0; tip[start+ol.count] != '\0' && ol.count < max_ll_cap; ol.count++)
             if (tip[start+ol.count] == ' ' && ol.count > nom_ll)
                 break;
         if (ol.count > max_ll)
@@ -52,9 +67,18 @@ void tooltip (const SCoord &s, const char *tip)
     tip_b.w = max_ll * TT_FONTW + 2*TT_BORDER;
     tip_b.h = n_lines * TT_ROWH + TT_BORDER;
 
-    // set location at s but beware right and bottom edges
-    tip_b.x = s.x + tip_b.w >= tft.width() ? tft.width() - tip_b.w : s.x;
-    tip_b.y = s.y + tip_b.h >= tft.height() ? tft.height() - tip_b.h : s.y;
+    // set location at s but beware right and bottom edges -- clamp to bound if given, else to
+    // the whole screen as before
+    uint16_t lo_x = bound ? bound->x : 0;
+    uint16_t hi_x = bound ? bound->x + bound->w : tft.width();
+    uint16_t lo_y = bound ? bound->y : 0;
+    uint16_t hi_y = bound ? bound->y + bound->h : tft.height();
+    tip_b.x = s.x + tip_b.w >= hi_x ? (tip_b.w >= hi_x - lo_x ? lo_x : hi_x - tip_b.w) : s.x;
+    tip_b.y = s.y + tip_b.h >= hi_y ? (tip_b.h >= hi_y - lo_y ? lo_y : hi_y - tip_b.h) : s.y;
+    if (tip_b.x < lo_x)
+        tip_b.x = lo_x;
+    if (tip_b.y < lo_y)
+        tip_b.y = lo_y;
 
     // get current pixels
     uint8_t *backing_store;

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -2285,6 +2285,7 @@ void updateWiFi(PlotPane skip_pp)
             if (pc == PLOT_CH_STORMS)    fresh_redraw[PLOT_CH_STORMS] = true;
             if (pc == PLOT_CH_LAUNCHES)  fresh_redraw[PLOT_CH_LAUNCHES] = true;
             if (pc == PLOT_CH_BALLOONS)  fresh_redraw[PLOT_CH_BALLOONS] = true;
+            if (pc == PLOT_CH_APRSCLUSTER) fresh_redraw[PLOT_CH_APRSCLUSTER] = true;
 
             // go now
             next_update[pp] = 0;


### PR DESCRIPTION
tooltip/aprscluster: confine APRS tooltips to their own pane
wifi: force fresh redraw when APRS rotates back into a pane
earthmap: draw borders before sat/DX/PSK paths to fix z-order
ncdxf: erase beacons immediately when toggled off
bandactivity: update freshness caption every 1 min instead of 3
hamalert: correct "Setup pg 4" -> "Setup pg 7" placeholder text