### PR TITLE
Better OK and CANCEL buttons for touch screens

### DIFF
--- a/ESPHamClock/menu.cpp
+++ b/ESPHamClock/menu.cpp
@@ -717,12 +717,12 @@ bool runMenu (MenuInfo &menu)
     menu.menu_b.h = MENU_TBM + (n_tblrows + n_mt + n_footer + 1)*MENU_RH + MENU_TBM + MENU_BG;
 
     // set ok button size, don't know position yet
-    menu.ok_b.w = getTextWidth (ok_label) + MENU_BDX*2;
+    uint16_t min_ok_w = getTextWidth (ok_label) + MENU_BDX*2;
     menu.ok_b.h = MENU_RH;
 
     // create cancel button, set size but don't know position yet
     SBox cancel_b;
-    cancel_b.w = getTextWidth (cancel_label) + MENU_BDX*2;
+    uint16_t min_cancel_w = getTextWidth (cancel_label) + MENU_BDX*2;
     cancel_b.h = MENU_RH;
 
     // width is duplicated for each column plus add a bit of right margin
@@ -731,11 +731,11 @@ bool runMenu (MenuInfo &menu)
 
     // insure menu width accommodates ok and/or cancel buttons
     if (menu.cancel == M_NOCANCEL) {
-        if (menu.menu_b.w < MENU_BB + menu.ok_b.w + MENU_BB)
-            menu.menu_b.w = MENU_BB + menu.ok_b.w + MENU_BB;
+        if (menu.menu_b.w < MENU_BB + min_ok_w + MENU_BB)
+            menu.menu_b.w = MENU_BB + min_ok_w + MENU_BB;
     } else {
-        if (menu.menu_b.w < MENU_BB + menu.ok_b.w + MENU_BB + cancel_b.w + MENU_BB)
-            menu.menu_b.w = MENU_BB + menu.ok_b.w + MENU_BB + cancel_b.w + MENU_BB;
+        if (menu.menu_b.w < MENU_BB + min_ok_w + MENU_BB + min_cancel_w + MENU_BB)
+            menu.menu_b.w = MENU_BB + min_ok_w + MENU_BB + min_cancel_w + MENU_BB;
     }
 
 
@@ -749,15 +749,21 @@ bool runMenu (MenuInfo &menu)
 
     // now we can set ok and cancel button positions within the menu box
     if (menu.cancel == M_NOCANCEL) {
-        menu.ok_b.x = menu.menu_b.x + (menu.menu_b.w - menu.ok_b.w)/2;  // center
+        menu.ok_b.w = menu.menu_b.w - 2*MENU_BB;
+        menu.ok_b.x = menu.menu_b.x + MENU_BB;
         menu.ok_b.y = menu.menu_b.y + menu.menu_b.h - MENU_TBM - menu.ok_b.h;
         cancel_b.x = 0;
         cancel_b.y = 0;
+        cancel_b.w = 0;
+        cancel_b.h = 0;
     } else {
+        uint16_t btn_w = (menu.menu_b.w - 3*MENU_BB)/2;
+        menu.ok_b.w = btn_w;
         menu.ok_b.x = menu.menu_b.x + MENU_BB;
         menu.ok_b.y = menu.menu_b.y + menu.menu_b.h - MENU_TBM - menu.ok_b.h;
-        cancel_b.x = menu.menu_b.x + menu.menu_b.w - cancel_b.w - MENU_BB;
-        cancel_b.y = menu.menu_b.y + menu.menu_b.h - MENU_TBM - cancel_b.h;
+        cancel_b.w = btn_w;
+        cancel_b.x = menu.ok_b.x + btn_w + MENU_BB;
+        cancel_b.y = menu.ok_b.y;
     }
 
     // menu_b is now properly positioned
@@ -774,12 +780,16 @@ bool runMenu (MenuInfo &menu)
     // display ok/cancel buttons
     fillSBox (menu.ok_b, MENU_BGC);
     drawSBox (menu.ok_b, MENU_FGC);
-    tft.setCursor (menu.ok_b.x+MENU_BDX, menu.ok_b.y + MENU_BDROP);
+    uint16_t ok_txt_w = getTextWidth (ok_label);
+    uint16_t ok_tx = menu.ok_b.x + (menu.ok_b.w > ok_txt_w ? (menu.ok_b.w - ok_txt_w)/2 : MENU_BDX);
+    tft.setCursor (ok_tx, menu.ok_b.y + MENU_BDROP);
     tft.print (ok_label);
     if (menu.cancel == M_CANCELOK) {
         fillSBox (cancel_b, MENU_BGC);
         drawSBox (cancel_b, MENU_FGC);
-        tft.setCursor (cancel_b.x+MENU_BDX, cancel_b.y + MENU_BDROP);
+        uint16_t cancel_txt_w = getTextWidth (cancel_label);
+        uint16_t cancel_tx = cancel_b.x + (cancel_b.w > cancel_txt_w ? (cancel_b.w - cancel_txt_w)/2 : MENU_BDX);
+        tft.setCursor (cancel_tx, cancel_b.y + MENU_BDROP);
         tft.print (cancel_label);
     }
 
@@ -992,7 +1002,9 @@ void menuRedrawOk (SBox &ok_b, MenuOkState oks)
     }
 
     selectFontStyle (LIGHT_FONT, FAST_FONT);
-    tft.setCursor (ok_b.x+MENU_BDX, ok_b.y + MENU_BDROP);
+    uint16_t ok_txt_w = getTextWidth (ok_label);
+    uint16_t ok_tx = ok_b.x + (ok_b.w > ok_txt_w ? (ok_b.w - ok_txt_w)/2 : MENU_BDX);
+    tft.setCursor (ok_tx, ok_b.y + MENU_BDROP);
     tft.print (ok_label);
 
     // immediate draw if over map

--- a/ESPHamClock/plotmgmnt.cpp
+++ b/ESPHamClock/plotmgmnt.cpp
@@ -736,23 +736,28 @@ static bool askPaneCategoryAccordion (PlotPane pp, SBox box, MenuItem *mitems, i
             row++;
 
             // Ok/Cancel row, also directly beneath whatever's currently visible
-            ok_b.w = ok_w;
+            uint16_t btn_w = (vis_box.w - 3*ACC_BB)/2;
+            ok_b.w = btn_w;
             ok_b.h = ACC_RH;
             ok_b.x = vis_box.x + ACC_BB;
             ok_b.y = vis_box.y + ACC_TBM + row*ACC_RH;
-            cancel_b.w = cancel_w;
+            cancel_b.w = btn_w;
             cancel_b.h = ACC_RH;
-            cancel_b.x = vis_box.x + vis_box.w - cancel_w - ACC_BB;
+            cancel_b.x = ok_b.x + btn_w + ACC_BB;
             cancel_b.y = ok_b.y;
 
             enable_ok = total_selected > 0;
             drawSBox (ok_b, enable_ok ? ACC_FGC : GRAY);
             tft.setTextColor (enable_ok ? ACC_FGC : GRAY);
-            tft.setCursor (ok_b.x + ACC_BDX, ok_b.y + ACC_BDROP);
+            uint16_t ok_txt_w = getTextWidth (acc_ok_label);
+            uint16_t ok_tx = ok_b.x + (ok_b.w > ok_txt_w ? (ok_b.w - ok_txt_w)/2 : ACC_BDX);
+            tft.setCursor (ok_tx, ok_b.y + ACC_BDROP);
             tft.print (acc_ok_label);
             drawSBox (cancel_b, ACC_FGC);
             tft.setTextColor (ACC_FGC);
-            tft.setCursor (cancel_b.x + ACC_BDX, cancel_b.y + ACC_BDROP);
+            uint16_t cancel_txt_w = getTextWidth (acc_cancel_label);
+            uint16_t cancel_tx = cancel_b.x + (cancel_b.w > cancel_txt_w ? (cancel_b.w - cancel_txt_w)/2 : ACC_BDX);
+            tft.setCursor (cancel_tx, cancel_b.y + ACC_BDROP);
             tft.print (acc_cancel_label);
 
             // publish immediately if anything we touched this frame -- newly drawn or newly

--- a/HC_RELEASE-beta.txt
+++ b/HC_RELEASE-beta.txt
@@ -4,4 +4,5 @@ Changes with latest release:
 - new HamAlert monitoring
 - new band activity pane
 - more ONTAs and highlights
+- touchscreen fixes for ok/cancel
 - touchscreen fixes for tooltips


### PR DESCRIPTION
It's really, really hard to tap the ok and cancel buttons on touch screens. The active button area is very small. The radio buttons word because their active area is very wide. Apply a similar technique to these buttons. It's so much better!