### PR TITLE
Add macros to call android for restart and exit

### DIFF
--- a/ESPHamClock/ArduinoLib.h
+++ b/ESPHamClock/ArduinoLib.h
@@ -198,6 +198,10 @@ extern const char *hc_version;
 extern bool version_https;
 extern std::string our_dir;
 extern void doExit(void);
+#if defined(_IS_ANDROID)
+extern "C" void android_request_restart(void);
+extern "C" void android_request_exit(void);
+#endif
 extern bool testPassword (const char *category, const char *candidate_pw);
 extern const char *pw_file;
 extern bool NVReadX11Geom (int &x, int &y, int &w, int &h);

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -2617,8 +2617,13 @@ static void runShutdownMenu(void)
 void doReboot(bool minus_K, bool minus_0)
 {
     defaultState();
+#if defined(_IS_ANDROID)
+    android_request_restart();
+    for(;;);
+#else
     ESP.restart (minus_K, minus_0);
     for(;;);
+#endif
 }
 
 /* do exit, as best we can
@@ -2631,7 +2636,12 @@ void doExit()
         // X11 calls doExit on window close, so drawing would be recursive back to that thread
         eraseScreen();
     #endif
+#if defined(_IS_ANDROID)
+    android_request_exit();
+    for(;;);
+#else
     _exit(0);
+#endif
 }
 
 /* call to display one final message, never returns


### PR DESCRIPTION
Restart and exit can't be done from inside the c++ without issues. Previuosly we ifdef these options out. Now with new features in android we can ifdef calls into android for these functions