### PR TITLE
Fix cancel button overflow

### DIFF
--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -472,7 +472,7 @@ static void drawMapPopup(void)
     Serial.printf ("POPUP before: pan_x %d pan_y %d zoom %d\n", pan_zoom.pan_x, pan_zoom.pan_y,
                                 pan_zoom.zoom);
 
-    const int ZINDENT = 2;
+    const int ZINDENT = 5;
 
     bool zoom_ok = map_proj == MAPP_MERCATOR;
     bool pan_ok = map_proj == MAPP_MERCATOR || map_proj == MAPP_ROB;

--- a/ESPHamClock/menu.cpp
+++ b/ESPHamClock/menu.cpp
@@ -734,8 +734,9 @@ bool runMenu (MenuInfo &menu)
         if (menu.menu_b.w < MENU_BB + min_ok_w + MENU_BB)
             menu.menu_b.w = MENU_BB + min_ok_w + MENU_BB;
     } else {
-        if (menu.menu_b.w < MENU_BB + min_ok_w + MENU_BB + min_cancel_w + MENU_BB)
-            menu.menu_b.w = MENU_BB + min_ok_w + MENU_BB + min_cancel_w + MENU_BB;
+        uint16_t min_btn_w = min_cancel_w > min_ok_w ? min_cancel_w : min_ok_w;
+        if (menu.menu_b.w < 2 * min_btn_w + 3 * MENU_BB)
+            menu.menu_b.w = 2 * min_btn_w + 3 * MENU_BB;
     }
 
 


### PR DESCRIPTION
The recent touchscreen fix to make OK and Cancel more accessible seems to have created this. Fix a math error that didn't make the buttons bigger on a small popup. The popup is now bigger as a result but it works.