### PR TITLE
Fix a play api bug and change workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,6 @@ jobs:
           releaseFiles: dist/org.openhamclock*.aab
           tracks: alpha
           status: draft
-          changesNotSentForReview: true
           whatsNewDirectory: dist/whatsnew
           mappingFile: dist/mapping.txt
 
@@ -210,8 +209,9 @@ jobs:
 
   docker:
     name: Build and Push Docker Image
+    needs: release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || inputs.build_docker == true || inputs.build_docker == 'true' }}
+    if: ${{ needs.release.result == 'success' && (github.event_name == 'push' || inputs.build_docker == true || inputs.build_docker == 'true') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -176,7 +176,7 @@ base64 -w 0 path/to/release.keystore | gh secret set ANDROID_KEYSTORE_BASE64
 
 ## 4. Pipeline Jobs & Artifacts
 
-The release workflow executes two parallel jobs: `release` and `docker`.
+The release workflow executes two jobs sequentially: `release` followed by `docker` (ensuring Docker images are only built and pushed if the release succeeds).
 
 ### Job 1: `release`
 


### PR DESCRIPTION
Let's not build docker until we no the tag and andriod built ok. Having it run in parallel is nice but we shouldn't leave artifacts in a mixed state if there's an issue.