### PR TITLE
Customize User-Agent to HamClock-amazon for Amazon Fire devices

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -3730,7 +3730,11 @@ extern bool parseWebCommand (WebArgs &wa, char line[], size_t line_len);
 extern void initWebServer(void);
 extern void checkWebServer(bool ro);
 extern TouchType readCalTouchWS (SCoord &s);
+#if defined(_IS_ANDROID) || defined(__ANDROID__)
+extern char platform[32];
+#else
 extern const char platform[];
+#endif
 extern void runNextDemoCommand(void);
 extern bool bypass_pw;
 

--- a/ESPHamClock/webserver.cpp
+++ b/ESPHamClock/webserver.cpp
@@ -10,7 +10,7 @@
 #if defined (_IS_ESP8266)
 const char platform[] = "ESPHamClock";
 #elif defined(_IS_ANDROID) || defined(__ANDROID__)
-const char platform[] = "HamClock-android";
+char platform[32] = "HamClock-android";
 #elif defined(_IS_LINUX_ARMBIAN)
 const char platform[] = "HamClock-armbian";
 #elif defined(_IS_LINUX_RPI)

--- a/android/app/src/main/cpp/hamclock_jni.cpp
+++ b/android/app/src/main/cpp/hamclock_jni.cpp
@@ -8,6 +8,8 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <strings.h>
+#include <sys/system_properties.h>
 #include <android/log.h>
 
 #include "HamClock.h"
@@ -276,7 +278,19 @@ static void *daemon_worker(void *arg) {
              ll.lat_d, ll.lng_d, grid, de_tz.tz_secs / 60);
     }
 
-    std::string progName = "hamclock-android";
+    char mfg[PROP_VALUE_MAX] = {0};
+    char brand[PROP_VALUE_MAX] = {0};
+    __system_property_get("ro.product.manufacturer", mfg);
+    __system_property_get("ro.product.brand", brand);
+    bool isAmazon = (strcasecmp(mfg, "Amazon") == 0 || strcasecmp(brand, "Amazon") == 0);
+
+    std::string progName = isAmazon ? "hamclock-amazon" : "hamclock-android";
+    if (isAmazon) {
+        snprintf(platform, sizeof(platform), "HamClock-amazon");
+        LOGI("Detected Amazon device (mfg: '%s', brand: '%s'): using platform '%s'", mfg, brand, platform);
+    } else {
+        LOGI("Detected Android device (mfg: '%s', brand: '%s'): using platform '%s'", mfg, brand, platform);
+    }
     std::string dirFlag = "-d";
     std::string dirVal = dargs->dataDir;
     std::string rwFlag = "-w";


### PR DESCRIPTION
### Summary

Automatically detects Amazon devices at runtime on Android (via `ro.product.manufacturer` and `ro.product.brand`) and updates the `platform` identifier and daemon process name to `HamClock-amazon` (keeping standard Android devices as `HamClock-android`).

### Details
- In `HamClock.h`, declared `extern char platform[32];` for Android builds while leaving other platforms const.
- In `webserver.cpp`, defined `char platform[32] = "HamClock-android";` for Android so it can be safely updated at startup.
- In `hamclock_jni.cpp`, queried manufacturer and brand properties before starting `hamclock_main`. If either matches `"Amazon"`, `platform` and `progName` are set to `HamClock-amazon` / `hamclock-amazon`.

### Verification
- Built Android APK with `./gradlew assembleDebug` (all ABIs: arm64-v8a, armeabi-v7a, x86_64).
- Built host target with `make -C ESPHamClock hamclock-fb0-1600x960` to verify no regression on non-Android platforms.