### PR TITLE
Fix errant paste prompt on Cancel/OK clicks in liveweb lower-left pane

### DIFF
--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -1987,6 +1987,7 @@ extern void initLiveWeb(bool verbose);
 extern bool liveweb_fs_ready;
 extern int n_roweb, n_rwweb;
 extern void openLiveWebURL (const char *url);
+extern void requestLiveWebPaste (void);
 extern bool isLiveWebTouch (void);
 
 

--- a/ESPHamClock/configs.cpp
+++ b/ESPHamClock/configs.cpp
@@ -860,6 +860,7 @@ static bool askConfigName (const char *title, const char *prompt, char name[], s
                 drawModalInputBox (input_b, edit_buf, cursor);
             } else {
                 tft.pasteClipboard();
+                requestLiveWebPaste();
             }
             wdDelay (150);
             drawStringInBox ("Paste", modal_paste_b, false, RA8875_CYAN);

--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -446,6 +446,24 @@ char live_html[] =  R"_raw_html_(
                         }
                     }
 
+                    else if (e.data === 'paste') {
+                        if (navigator.clipboard && navigator.clipboard.readText) {
+                            navigator.clipboard.readText().then(text => {
+                                if (text)
+                                    pasteString(text);
+                            }).catch(err => {
+                                console.log("clipboard read denied: ", err);
+                                let text = prompt("Paste text here (Ctrl+V):", "");
+                                if (text)
+                                    pasteString(text);
+                            });
+                        } else {
+                            let text = prompt("Paste text here (Ctrl+V):", "");
+                            if (text)
+                                pasteString(text);
+                        }
+                    }
+
                     else if (e.data === 'Too many connections') {       // N.B. string must match liveweb.cpp
                         // close and don't reload
                         drawMsgOnce (e.data);
@@ -564,26 +582,6 @@ char live_html[] =  R"_raw_html_(
                 var mods = event.ctrlKey || event.metaKey;
                 var button = ((event.button == 0 && mods) || event.button == 1 || event.button == 2) ? 1 : 0;
                 console.log ("button " + event.button + " + " + mods + " -> " + button);
-
-                // if tapping on virtual keyboard Paste button in non-Android browser, read browser clipboard
-                // Only trigger on primary button (left click / touch tap) without keyboard modifiers
-                if (event.button === 0 && !mods && m.x >= 16 && m.x <= 155 && m.y >= 404 && m.y <= 470 && !window.AndroidApp) {
-                    if (navigator.clipboard && navigator.clipboard.readText) {
-                        navigator.clipboard.readText().then(text => {
-                            if (text)
-                                pasteString(text);
-                        }).catch(err => {
-                            console.log("clipboard read denied: ", err);
-                            let text = prompt("Paste text here (Ctrl+V):", "");
-                            if (text)
-                                pasteString(text);
-                        });
-                    } else {
-                        let text = prompt("Paste text here (Ctrl+V):", "");
-                        if (text)
-                            pasteString(text);
-                    }
-                }
 
                 // compose and send
                 let msg = 'set_touch?x=' + m.x + '&y=' + m.y + '&button=' + button;

--- a/ESPHamClock/liveweb.cpp
+++ b/ESPHamClock/liveweb.cpp
@@ -46,6 +46,7 @@ const int liveweb_maxmax = MAX_CLIENTS-1;               // max max for -help
 // record client and possible URL for it to display.
 static ws_cli_conn_t *lastest_ws_touch_client;          // most recent client performing set_touch
 static char *liveweb_openurl;                           // malloced url to attempt to open, else NULL
+static bool liveweb_dopaste;                            // client should attempt paste
 static pthread_mutex_t lw_url_lock = PTHREAD_MUTEX_INITIALIZER; // thread-safe access for liveweb_openurl
 
 
@@ -469,16 +470,21 @@ static void getLiveUpdate (ws_cli_conn_t *client, char args[], size_t args_len)
     if (liveweb_fs_ready && getWebFullScreen())
         sendFullScreen (client);
 
-    // check for pending openurl if this client did a touch
+    // check for pending openurl or paste if this client did a touch
     pthread_mutex_lock (&lw_url_lock);
     if (lastest_ws_touch_client == client) {
+        if (liveweb_dopaste) {
+            Serial.printf ("LIVE: sending paste command\n");
+            ws_sendframe_txt (client, "paste");
+            liveweb_dopaste = false;
+        }
         if (liveweb_openurl) {
             Serial.printf ("LIVE: sending URL %s\n", liveweb_openurl);
             sendURL (client, liveweb_openurl);
             free (liveweb_openurl);
             liveweb_openurl = NULL;
-            lastest_ws_touch_client = NULL;
         }
+        lastest_ws_touch_client = NULL;
     }
     pthread_mutex_unlock (&lw_url_lock);
 
@@ -1002,6 +1008,18 @@ void openLiveWebURL (const char *url)
     }
     liveweb_openurl = strdup (url);
     Serial.printf ("LIVE: live web staging URL %s\n", url);
+    pthread_mutex_unlock (&lw_url_lock);
+}
+
+/* record desire for most recent touch client to paste from clipboard.
+ */
+void requestLiveWebPaste (void)
+{
+    pthread_mutex_lock (&lw_url_lock);
+    if (lastest_ws_touch_client) {
+        liveweb_dopaste = true;
+        Serial.printf ("LIVE: live web staging paste request\n");
+    }
     pthread_mutex_unlock (&lw_url_lock);
 }
 

--- a/ESPHamClock/setup.cpp
+++ b/ESPHamClock/setup.cpp
@@ -5313,6 +5313,7 @@ static void runSetup()
                         checkLLGEdit (sp);
                 } else {
                     tft.pasteClipboard();
+                    requestLiveWebPaste();
                 }
                 wdDelay (150);
                 drawStringInBox ("Paste", paste_b, false, RA8875_CYAN);


### PR DESCRIPTION
(These AI summaries are great! We really need better commit messages.)

### Problem
In `liveweb-html.cpp`, a client-side coordinate bounding box check `m.x in [16..155] && m.y in [404..470]` was used to detect clicks on the virtual keyboard's "Paste" button. However, this pixel box directly overlaps the **Cancel** and **OK** buttons at the bottom of Pane 0 (lower-left pane) when satellite, DX, or other configuration dialogs are open. When clicked in Chrome, `navigator.clipboard.readText()` fails without explicit permissions / over HTTP, popping up the `prompt("Paste text here (Ctrl+V):", "")` dialog.

### Solution
- **Removed** client-side pixel coordinate guessing from `liveweb-html.cpp`.
- **Added** server-driven paste notification via `requestLiveWebPaste()` and WebSocket text message `"paste"` when the user actually taps the on-screen Paste button on keyboard pages (`setup.cpp`, `configs.cpp`).
- Browser client listens for `paste` message in `ws.onmessage` and pastes clipboard content.
- Native `Ctrl+V` / `Cmd+V` handling remains unchanged.

### Verification
- Host build `make -C ESPHamClock hamclock-fb0-1600x960` passed with 0 errors.
- Android build `./gradlew compileDebugSources assembleDebug` passed with 0 errors.