### PR TITLE
Fix Fire TV remote D-pad navigation in settings dialog

### DIFF
--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -333,6 +333,9 @@ class MainActivity : AppCompatActivity() {
             WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
             WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
         )
+        dialogView.post {
+            cbAllowExternal.requestFocus()
+        }
     }
 
     private fun clearHamClockCache(dataDir: File) {

--- a/android/app/src/main/res/drawable/btn_exit_selector.xml
+++ b/android/app/src/main/res/drawable/btn_exit_selector.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#B22222" />
+            <stroke android:width="2dp" android:color="#FF5252" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#5A0000" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#8B0000" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/btn_neutral_selector.xml
+++ b/android/app/src/main/res/drawable/btn_neutral_selector.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#546E7A" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#263238" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#37474F" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/btn_setup_selector.xml
+++ b/android/app/src/main/res/drawable/btn_setup_selector.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#3D5A80" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#1A252F" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#2C3E50" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/item_focus_highlight.xml
+++ b/android/app/src/main/res/drawable/item_focus_highlight.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#26FFFFFF" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#3DFFFFFF" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/layout/dialog_backend_settings.xml
+++ b/android/app/src/main/res/layout/dialog_backend_settings.xml
@@ -2,15 +2,15 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:focusable="false"
     android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:descendantFocusability="beforeDescendants"
+        android:focusable="false"
+        android:descendantFocusability="afterDescendants"
         android:paddingStart="24dp"
         android:paddingEnd="24dp"
         android:paddingTop="12dp"
@@ -20,6 +20,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:focusable="false"
         android:layout_marginBottom="8dp">
 
         <Button
@@ -30,7 +31,8 @@
             android:layout_marginEnd="6dp"
             android:text="@string/open_setup"
             android:textColor="@color/hamclock_text"
-            android:backgroundTint="#2C3E50" />
+            android:background="@drawable/btn_setup_selector"
+            android:focusable="true" />
 
         <Button
             android:id="@+id/btn_exit_app"
@@ -40,7 +42,8 @@
             android:layout_marginStart="6dp"
             android:text="@string/exit_hamclock"
             android:textColor="@color/hamclock_text"
-            android:backgroundTint="#8B0000" />
+            android:background="@drawable/btn_exit_selector"
+            android:focusable="true" />
     </LinearLayout>
 
     <View
@@ -68,7 +71,10 @@
         android:imeOptions="flagNoExtractUi|actionDone"
         android:singleLine="true"
         android:textColor="@color/hamclock_text"
-        android:textColorHint="#888888" />
+        android:textColorHint="#888888"
+        android:focusable="true"
+        android:padding="8dp"
+        android:background="@drawable/item_focus_highlight" />
 
     <View
         android:layout_width="match_parent"
@@ -84,13 +90,18 @@
         android:text="@string/start_on_boot_label"
         android:textColor="@color/hamclock_text"
         android:textSize="14sp"
-        android:buttonTint="@color/hamclock_accent" />
+        android:buttonTint="@color/hamclock_accent"
+        android:focusable="true"
+        android:clickable="true"
+        android:padding="8dp"
+        android:background="@drawable/item_focus_highlight" />
 
     <LinearLayout
         android:id="@+id/ll_autostart_helper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:focusable="false"
         android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
@@ -114,7 +125,8 @@
             android:text="@string/open_autostart_settings"
             android:textColor="@color/hamclock_text"
             android:textSize="12sp"
-            android:backgroundTint="#455A64" />
+            android:background="@drawable/btn_neutral_selector"
+            android:focusable="true" />
     </LinearLayout>
 
     <View
@@ -131,13 +143,18 @@
         android:text="@string/allow_external_label"
         android:textColor="@color/hamclock_text"
         android:textSize="14sp"
-        android:buttonTint="@color/hamclock_accent" />
+        android:buttonTint="@color/hamclock_accent"
+        android:focusable="true"
+        android:clickable="true"
+        android:padding="8dp"
+        android:background="@drawable/item_focus_highlight" />
 
     <LinearLayout
         android:id="@+id/ll_local_access_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:focusable="false"
         android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
@@ -164,7 +181,10 @@
             android:singleLine="true"
             android:textSize="13sp"
             android:textColor="@color/hamclock_text"
-            android:textColorHint="#888888" />
+            android:textColorHint="#888888"
+            android:focusable="true"
+            android:padding="8dp"
+            android:background="@drawable/item_focus_highlight" />
 
         <TextView
             android:layout_width="match_parent"
@@ -192,7 +212,8 @@
             android:text="@string/copy_url"
             android:textColor="@color/hamclock_text"
             android:textSize="12sp"
-            android:backgroundTint="#37474F" />
+            android:background="@drawable/btn_neutral_selector"
+            android:focusable="true" />
     </LinearLayout>
 
     <View


### PR DESCRIPTION
Enable selecting settings boxes in the android settings page, which was broken, on amazon fire tv. If we can enable local web access, then we can configure HamClock with a computer on the local network.

- Remove descendantFocusability and container focusability in dialog_backend_settings.xml so D-pad can reach checkboxes and buttons
- Add visible focus selectors for checkboxes and buttons for TV remote navigation
- Auto-focus allow local network access checkbox on settings dialog open