### PR TITLE
Fix android iframe popups

### DIFF
--- a/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
+++ b/ESPHamClock/ArduinoLib/Adafruit_RA8875.cpp
@@ -2149,6 +2149,31 @@ void Adafruit_RA8875::saveWinGeom(void)
         NVWriteX11Geom (winpos_now_x, winpos_now_y, winpos_now_w, winpos_now_h);
 }
 
+/* return the app window's absolute position and size on the X screen -- same XGetWindowAttributes
+ * + XTranslateCoordinates approach as saveWinGeom(), just returned to the caller instead of
+ * persisted to NV. used to position companion popup windows, eg the ADS-B Chromium app-mode
+ * popup (see qrz.cpp), so it lands near the HamClock window instead of wherever the window
+ * manager feels like putting it.
+ */
+// _USE_X11
+bool Adafruit_RA8875::getWinScreenGeom (int *x, int *y, int *w, int *h)
+{
+        XWindowAttributes xwa;
+        if (!XGetWindowAttributes (display, win, &xwa) || xwa.map_state != IsViewable)
+            return (false);
+
+        Screen *screen = XDefaultScreenOfDisplay (display);
+        int screen_num = XScreenNumberOfScreen(screen);
+        Window root = RootWindow(display,screen_num);
+
+        Window child;
+        if (!XTranslateCoordinates (display, win, root, 0, 0, x, y, &child))
+            return (false);
+        *w = xwa.width;
+        *h = xwa.height;
+        return (true);
+}
+
 
 /* return Button code from event.
  * N.B. must be used both in ButtonPress and ButtonRelease
@@ -2577,6 +2602,13 @@ void Adafruit_RA8875::getScreenSize (int *w, int *h)
 {
         *w = fb_si.xres;
         *h = fb_si.yres;
+}
+
+// _WEB_ONLY -- no separate window to query; nothing to embed a popup near
+bool Adafruit_RA8875::getWinScreenGeom (int *x, int *y, int *w, int *h)
+{
+        (void)x; (void)y; (void)w; (void)h;
+        return (false);
 }
 
 #endif // _WEB_ONLY
@@ -3085,6 +3117,13 @@ void Adafruit_RA8875::getScreenSize (int *w, int *h)
 {
         *w = FB_XRES;
         *h = FB_YRES;
+}
+
+// _USE_FB0 -- no windowing layer at all; HamClock owns the whole framebuffer
+bool Adafruit_RA8875::getWinScreenGeom (int *x, int *y, int *w, int *h)
+{
+        (void)x; (void)y; (void)w; (void)h;
+        return (false);
 }
 
 #endif // _USE_FB0

--- a/ESPHamClock/ArduinoLib/Adafruit_RA8875.h
+++ b/ESPHamClock/ArduinoLib/Adafruit_RA8875.h
@@ -217,6 +217,12 @@ class Adafruit_RA8875 {
             gray_type = g;
         };
 
+        // return the app window's absolute position and size on the X screen, for positioning
+        // companion popup windows (eg the ADS-B Chromium app-mode popup, see qrz.cpp). only
+        // meaningful with _USE_X11; returns false everywhere else (fb0, ESP32, Android) since
+        // there's no separate windowing layer to query.
+        bool getWinScreenGeom (int *x, int *y, int *w, int *h);
+
     protected:
 
 	// 0: normal 2: 180 degs

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -512,6 +512,34 @@ void setup()
         fires_btn_b.h = view_btn_b.h;
     }
 
+    // seed the ADS-B on-map badge just to the right of View, same convention as Fires: it can be
+    // showing alongside Borders/Fires (all apply to Clouds), so it can't share a fixed slot either --
+    // drawADSBBadge() recomputes adsbmap_btn_b.x every draw to float right of whichever of
+    // View/Borders/Fires is currently rightmost. This is just a harmless initial value.
+    {
+        const int gap = 4;
+        const int pad = 8;
+        selectFontStyle (LIGHT_FONT, FAST_FONT);
+        adsbmap_btn_b.x = view_btn_b.x + view_btn_b.w + gap;
+        adsbmap_btn_b.y = view_btn_b.y;
+        adsbmap_btn_b.w = getTextWidth ("ADS-B") + pad;
+        adsbmap_btn_b.h = view_btn_b.h;
+    }
+
+    // seed the Wind on-map badge just to the right of View, same convention: it can share the
+    // CM_WX row with WEFAX, so it can't take a fixed slot either -- drawWindButton() recomputes
+    // windmap_btn_b.x every draw to float right of WEFAX, or View when WEFAX isn't enabled. This
+    // is just a harmless initial value.
+    {
+        const int gap = 4;
+        const int pad = 8;
+        selectFontStyle (LIGHT_FONT, FAST_FONT);
+        windmap_btn_b.x = view_btn_b.x + view_btn_b.w + gap;
+        windmap_btn_b.y = view_btn_b.y;
+        windmap_btn_b.w = getTextWidth ("Wind") + pad;
+        windmap_btn_b.h = view_btn_b.h;
+    }
+
     // redefine callsign for main screen
     cs_info.box.x = 0;
     cs_info.box.y = 0;
@@ -964,6 +992,10 @@ static void checkTouch()
         drawFiresButton();
         drawFiresOnMap();
         tft.drawPR();
+    } else if (adsbBadgeVisible() && inBox (s, adsbmap_btn_b)) {
+        adsbBadgeClicked();
+    } else if (windBadgeVisible() && inBox (s, windmap_btn_b)) {
+        windBadgeClicked();
     } else if (checkSatMapTouch (s)) {
         // set showing sat in DX box
         dx_info_for_sat = true;

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -685,6 +685,18 @@ extern void initFires(void);            // restore NV state at startup
 extern void updateFires(void);          // fetch from OHB if due; call from updateWiFi()
 extern void drawFiresOnMap(void);       // render flame glyphs; call from drawAllSymbols()
 
+extern SBox adsbmap_btn_b;              // on-map "ADS-B" badge; slot floats right of whichever
+                                         // of View/Borders/Fires is currently rightmost
+extern bool adsbBadgeVisible(void);     // whether that badge should currently be shown -- Clouds
+                                         // + Mercator/Robinson only
+extern void drawADSBBadge(void);        // draw (or blank) the badge
+extern void adsbBadgeClicked(void);     // open ADS-B Exchange (or PiAware) centered on DE
+
+extern SBox windmap_btn_b;              // on-map "Wind" badge; slot floats right of WEFAX, or View
+extern bool windBadgeVisible(void);     // whether that badge should currently be shown -- CM_WX only
+extern void drawWindButton(void);       // draw (or blank) the badge
+extern void windBadgeClicked(void);     // open Windy.com centered on DE
+
 extern SBox desrss_b, dxsrss_b;         // sun rise/set display
 extern uint8_t desrss, dxsrss;          // sun rise/set chpice
 enum {
@@ -765,8 +777,6 @@ extern SBox map_b;                      // main map
 extern SBox view_btn_b;                 // map view menu button
 
 extern SBox motd_btn_b;                 // MOTD mailbox icon (next to UTC button)
-extern SBox adsb_btn_b;                 // ADS-B airplane icon (next to MOTD icon)
-extern SBox windy_btn_b;                // Windy.com wind icon (next to ADS-B icon)
 
 // MOTD (Message of the Day) functions
 extern void checkMOTD (void);
@@ -774,11 +784,6 @@ extern bool motdIsPresent (void);
 extern void drawMOTDIcon (void);
 extern void motdClicked (void);
 
-// ADS-B airplane icon -- opens https://adsb.lol
-extern void drawADSBIcon (void);
-
-// Windy.com wind icon -- opens https://www.windy.com
-extern void drawWindyIcon (void);
 extern SBox dx_maid_b;                  // dx maidenhead pick
 extern SBox de_maid_b;                  // de maidenhead pick
 extern SBox lkscrn_b;                   // screen lock icon button
@@ -1987,6 +1992,8 @@ extern void initLiveWeb(bool verbose);
 extern bool liveweb_fs_ready;
 extern int n_roweb, n_rwweb;
 extern void openLiveWebURL (const char *url);
+extern void openLiveWebURLEmbedded (const char *url);
+extern void requestLiveWebPaste (void);
 extern bool isLiveWebTouch (void);
 
 
@@ -2705,6 +2712,8 @@ extern QRZURLTable qrz_urltable[QRZ_N];
 
 extern void openQRZBio (const DXSpot &s);
 extern void openURL (const char *url);
+extern void openURLPopup (const char *url);
+extern void openURLPopupEmbed (const char *url);
 extern void openMovieURL (const char *hc_page, const char *orig_url);
 
 
@@ -3731,7 +3740,11 @@ extern bool parseWebCommand (WebArgs &wa, char line[], size_t line_len);
 extern void initWebServer(void);
 extern void checkWebServer(bool ro);
 extern TouchType readCalTouchWS (SCoord &s);
+#if defined(_IS_ANDROID) || defined(__ANDROID__)
+extern char platform[32];
+#else
 extern const char platform[];
+#endif
 extern void runNextDemoCommand(void);
 extern bool bypass_pw;
 

--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -89,6 +89,7 @@ OBJS = \
 	P13.o \
 	adif.o \
 	adif_parser.o \
+	adsbbadge.o \
 	activenets.o \
 	balloons.o \
     antenna_lookup.o \
@@ -190,6 +191,7 @@ OBJS = \
 	watchlist.o \
 	wifi.o \
 	wifimeter.o \
+	windbadge.o \
 	wx.o \
 	xota.o \
 	zones.o

--- a/ESPHamClock/Makefile
+++ b/ESPHamClock/Makefile
@@ -89,7 +89,7 @@ OBJS = \
 	P13.o \
 	adif.o \
 	adif_parser.o \
-	adsbbadge.o \
+	adsbbadge.o  \
 	activenets.o \
 	balloons.o \
     antenna_lookup.o \

--- a/ESPHamClock/adsbbadge.cpp
+++ b/ESPHamClock/adsbbadge.cpp
@@ -1,0 +1,93 @@
+/* adsbbadge.cpp -- on-map "ADS-B" badge for HamClock
+ *
+ * Unlike the Borders/Fires badges this has no on/off state of its own and draws nothing onto the
+ * map itself -- it's just a link button, same idea as the WEFAX/Wind badges (which launch/link
+ * out instead of toggling an overlay). Tapping it opens ADS-B Exchange's live globe map, centered
+ * on DE, via openURLPopupEmbed() -- see qrz.cpp.
+ *
+ * On-map presence, not buried in the map menu: shown on Countries, Terrain, Clouds (the maps
+ * Borders/Fires can appear on) and Weather (the map WEFAX/Wind appear on), in any projection.
+ * Borders/Fires restrict themselves to the Mercator/Robinson projections because they toggle a
+ * map overlay that only renders sensibly in those -- that restriction doesn't apply here, since
+ * this badge doesn't draw anything on the map itself, just floats along the always-present View
+ * button's row (which exists regardless of projection) and opens a link when tapped.
+ */
+
+#include "HamClock.h"
+
+SBox adsbmap_btn_b;                    // extern; badge box, geometry set each draw (floats with Borders/Fires)
+
+/* return whether the on-map "ADS-B" badge should currently be shown.
+ * Countries, Terrain, Clouds, or Weather -- any projection, since this badge draws nothing onto
+ * the map and so has none of the rendering reasons Borders/Fires restrict themselves to Mercator/
+ * Robinson. Hiding it has no other side effect: there's no persisted state to preserve, unlike
+ * Borders/Fires, since this badge doesn't toggle anything -- it's just a link.
+ */
+bool adsbBadgeVisible(void)
+{
+    return (core_map == CM_COUNTRIES || core_map == CM_TERRAIN
+                || core_map == CM_CLOUDS || core_map == CM_WX);
+}
+
+/* draw (or blank) the on-map "ADS-B" badge.
+ * Floats to the right of whichever badge is currently rightmost in its row: on
+ * Countries/Terrain/Clouds that's Fires, else Borders, else View; on Weather that's Wind, else
+ * WEFAX, else View. Recomputed here every draw, same convention as drawFiresButton()/
+ * drawWindButton() tracking their own neighbors.
+ */
+void drawADSBBadge(void)
+{
+    adsbmap_btn_b.y = view_btn_b.y;
+
+    if (!adsbBadgeVisible()) {
+        // wrong core map -- leave the map pixels already painted here alone.
+        return;
+    }
+
+    const int gap = 4;
+    const int pad = 8;
+    selectFontStyle (LIGHT_FONT, FAST_FONT);
+    uint16_t left_edge = view_btn_b.x + view_btn_b.w;
+    if (bordersBadgeVisible())
+        left_edge = borders_btn_b.x + borders_btn_b.w;
+    if (firesBadgeVisible())
+        left_edge = fires_btn_b.x + fires_btn_b.w;
+    if (wefaxBadgeVisible())
+        left_edge = wefax_btn_b.x + wefax_btn_b.w;
+    if (windBadgeVisible())
+        left_edge = windmap_btn_b.x + windmap_btn_b.w;
+    adsbmap_btn_b.x = left_edge + gap;
+    adsbmap_btn_b.w = getTextWidth ("ADS-B") + pad;
+    adsbmap_btn_b.h = view_btn_b.h;
+
+    // always the same "unpressed" look -- black fill, white outline/text -- since it has no
+    // on/off state, just Borders/Fires' normal (off) styling permanently.
+    tft.fillRect (adsbmap_btn_b.x, adsbmap_btn_b.y, adsbmap_btn_b.w-1, adsbmap_btn_b.h-1, RA8875_BLACK);
+    tft.drawRect (adsbmap_btn_b.x, adsbmap_btn_b.y, adsbmap_btn_b.w-1, adsbmap_btn_b.h-1, RA8875_WHITE);
+
+    const char *label = "ADS-B";
+    uint16_t lbl_w = getTextWidth(label);
+    tft.setCursor (adsbmap_btn_b.x+(adsbmap_btn_b.w-lbl_w)/2, adsbmap_btn_b.y+2);
+    tft.setTextColor (RA8875_WHITE);
+    tft.print (label);
+}
+
+/* open ADS-B Exchange's live globe map, centered on DE, or the user's PiAware receiver if one is
+ * configured in Setup -- same source and fallback as the ADS-B icon in the clock area (clocks.cpp).
+ * uses openURLPopupEmbed(): on the X11 desktop build this is a chromeless Chromium app-mode popup
+ * positioned near the HamClock window; under Live Web it's the in-page <iframe> overlay, since
+ * ADS-B Exchange's globe map is confirmed to allow being framed; anywhere else (fb0, ESP32,
+ * Android, or no Chromium found) it's a plain new browser tab -- see qrz.cpp.
+ * call this from checkTouch() when adsbBadgeVisible() && inBox(s, adsbmap_btn_b).
+ */
+void adsbBadgeClicked(void)
+{
+    char url[100];
+    const char *piaware_host = getPiAwareHost();
+    if (piaware_host[0])
+        snprintf (url, sizeof(url), "http://%s/skyaware/", piaware_host);
+    else
+        snprintf (url, sizeof(url), "https://globe.adsbexchange.com/?lat=%.3f&lon=%.3f&zoom=10",
+                    de_ll.lat_d, de_ll.lng_d);
+    openURLPopupEmbed (url);
+}

--- a/ESPHamClock/clocks.cpp
+++ b/ESPHamClock/clocks.cpp
@@ -4,62 +4,6 @@
 
 #include "HamClock.h"
 
-// ADS-B airplane icon -- opens https://adsb.lol (or the user's PiAware receiver, if configured in
-// Setup), sits just below the MOTD mailbox icon. kept small (matches MOTD icon size) to leave enough
-// clearance below for the Windy label before hitting auxtime_b (the date line).
-#define ADSB_ICON_W             14
-#define ADSB_ICON_H             14
-#define ADSB_ICON_BPR           ((ADSB_ICON_W + 7)/8) // bytes per bitmap row
-#define ADSB_ICON_GAP           3               // gap below MOTD icon
-#define ADSB_ICON_C_DEFAULT     RA8875_YELLOW    // color when using adsb.lol (no PiAware configured)
-#define ADSB_ICON_C_PIAWARE     RA8875_GREEN     // color when hyperlinking to a configured PiAware receiver
-SBox adsb_btn_b;
-
-// top-down airliner silhouette, one bit per pixel. zero bits are transparent.
-// rows are packed left-to-right, least-significant bit first, like santa.cpp.
-static const uint8_t adsb_plane[ADSB_ICON_BPR*ADSB_ICON_H] PROGMEM = {
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xe0, 0x01,
-    0xf8, 0x07,
-    0xfc, 0x0f,
-    0xc7, 0x38,
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xc0, 0x00,
-    0xf0, 0x03,
-    0xf0, 0x03,
-};
-
-// Windy.com wind icon -- opens https://www.windy.com centered on DE, sits just below the ADS-B icon.
-#define WINDY_ICON_W            14
-#define WINDY_ICON_H            14
-#define WINDY_ICON_BPR          ((WINDY_ICON_W + 7)/8) // bytes per bitmap row
-#define WINDY_ICON_GAP          3               // gap below ADS-B icon
-#define WINDY_ICON_C            RA8875_CYAN
-SBox windy_btn_b;
-
-// wind gust breeze streams icon with top swirl curl, one bit per pixel.
-static const uint8_t windy_icon[WINDY_ICON_BPR*WINDY_ICON_H] PROGMEM = {
-    0x80, 0x01,
-    0x40, 0x02,
-    0x7c, 0x00,
-    0x00, 0x00,
-    0x00, 0x00,
-    0xfe, 0x0f,
-    0x00, 0x38,
-    0x00, 0x30,
-    0x00, 0x00,
-    0x00, 0x06,
-    0xf8, 0x03,
-    0x00, 0x00,
-    0x00, 0x00,
-    0x00, 0x00,
-};
-
 // format flags
 uint8_t de_time_fmt;                            // one of DETIME_*
 uint8_t desrss, dxsrss;                         // show actual de/dx sun rise/set else time to
@@ -141,73 +85,9 @@ static void drawUTCButton()
 
     // defensively blank the icon column *below* the mailbox down to just above auxtime_b (the
     // date line, whose top edge sits 48px below clock_b.y by experiment) -- guards against stale
-    // pixels left over from a previous build's differently-sized icons in this same spot. N.B.
-    // must start below motd_btn_b's own bottom edge, not at its top -- starting at the top (as
-    // this used to) blanked the mailbox glyph drawMOTDIcon() had just painted, with nothing left
-    // to repaint it since ADS-B/Windy below only redraw their own icons.
+    // pixels left over from a previous build's icons in this same spot (ADS-B/Windy used to live
+    // here; both are now on-map badges instead, see adsbbadge.cpp/windbadge.cpp).
     tft.fillRect (motd_btn_b.x-3, motd_btn_b.y+motd_btn_b.h, motd_btn_b.w+6, 48-motd_btn_b.h, RA8875_BLACK);
-
-    // draw the ADS-B airplane icon just below that -- always shown, opens adsb.lol when tapped
-    drawADSBIcon();
-
-    // draw the Windy.com wind icon just below that -- always shown, opens windy.com when tapped
-    drawWindyIcon();
-}
-
-/* draw the ADS-B airplane icon immediately below the MOTD mailbox icon. always shown
- * (unlike the MOTD icon, which blanks itself when there's no message) -- tapping it opens
- * https://adsb.lol, a live ADS-B aircraft tracking site. should be called right after
- * drawMOTDIcon() since it positions itself relative to motd_btn_b.
- */
-void drawADSBIcon()
-{
-    // center the wider airplane below the mailbox while retaining one clickable bounding box.
-    adsb_btn_b.x = motd_btn_b.x - (ADSB_ICON_W - motd_btn_b.w)/2;
-    adsb_btn_b.y = motd_btn_b.y + motd_btn_b.h + ADSB_ICON_GAP;
-    adsb_btn_b.w = ADSB_ICON_W;
-    adsb_btn_b.h = ADSB_ICON_H;
-
-    // plane is drawn in a different color once the user has configured a PiAware receiver in Setup
-    uint16_t plane_c = getPiAwareHost()[0] ? ADSB_ICON_C_PIAWARE : ADSB_ICON_C_DEFAULT;
-
-    // erase the old icon, then paint only set bitmap pixels; zero bits remain background.
-    tft.fillRect (adsb_btn_b.x, adsb_btn_b.y, adsb_btn_b.w, adsb_btn_b.h, RA8875_BLACK);
-    for (uint16_t row = 0; row < ADSB_ICON_H; row++) {
-        for (uint16_t byte_col = 0; byte_col < ADSB_ICON_BPR; byte_col++) {
-            uint8_t bits = pgm_read_byte (&adsb_plane[row*ADSB_ICON_BPR + byte_col]);
-            for (uint16_t bit = 0; bit < 8; bit++) {
-                uint16_t col = 8*byte_col + bit;
-                if (col < ADSB_ICON_W && (bits & (1U << bit)))
-                    tft.drawPixel (adsb_btn_b.x + col, adsb_btn_b.y + row, plane_c);
-            }
-        }
-    }
-}
-
-/* draw the Windy.com wind icon immediately below the ADS-B airplane icon. always shown --
- * tapping it opens https://www.windy.com centered on DE's location. should be called right
- * after drawADSBIcon() since it positions itself relative to adsb_btn_b.
- */
-void drawWindyIcon()
-{
-    // center the wind icon below the airplane while retaining one clickable bounding box.
-    windy_btn_b.x = adsb_btn_b.x + (adsb_btn_b.w - WINDY_ICON_W)/2;
-    windy_btn_b.y = adsb_btn_b.y + adsb_btn_b.h + WINDY_ICON_GAP;
-    windy_btn_b.w = WINDY_ICON_W;
-    windy_btn_b.h = WINDY_ICON_H;
-
-    // erase the old icon, then paint set bitmap pixels in cyan.
-    tft.fillRect (windy_btn_b.x, windy_btn_b.y, windy_btn_b.w, windy_btn_b.h, RA8875_BLACK);
-    for (uint16_t row = 0; row < WINDY_ICON_H; row++) {
-        for (uint16_t byte_col = 0; byte_col < WINDY_ICON_BPR; byte_col++) {
-            uint8_t bits = pgm_read_byte (&windy_icon[row*WINDY_ICON_BPR + byte_col]);
-            for (uint16_t bit = 0; bit < 8; bit++) {
-                uint16_t col = 8*byte_col + bit;
-                if (col < WINDY_ICON_W && (bits & (1U << bit)))
-                    tft.drawPixel (windy_btn_b.x + col, windy_btn_b.y + row, WINDY_ICON_C);
-            }
-        }
-    }
 }
 
 /* function given to TimeLib's setSyncProvider() to resync its time base occasionally.
@@ -1165,9 +1045,9 @@ void updateClocks(bool all)
             // just came back on, show and update state
             Serial.printf ("time: back ok\n");
             // N.B. erase the '?' mark *before* drawUTCButton(), not after -- this rect
-            // (x:187-212, y:65-112 for a typical clock_b) overlaps the MOTD/ADS-B/Windy
-            // icon column, so drawing the icons first and erasing second was wiping them
-            // out with nothing left to redraw them.
+            // (x:187-212, y:65-112 for a typical clock_b) overlaps the MOTD icon column,
+            // so drawing the icon first and erasing second was wiping it out with nothing
+            // left to redraw it.
             tft.fillRect(clock_b.x+2*clock_b.w/3+34, clock_b.y, 25, HMS_H+4, RA8875_BLACK); // erase ?
             drawUTCButton();
 
@@ -1341,29 +1221,6 @@ bool checkClockTouch (SCoord &s)
         return (true);
     }
 
-    // ADS-B airplane icon: always present, opens the user's PiAware receiver if configured in Setup,
-    // else opens adsb.lol centered on DE's location
-    if (inPaddedBox (s, adsb_btn_b, ICON_HIT_PAD)) {
-        char url[100];
-        const char *piaware_host = getPiAwareHost();
-        if (piaware_host[0])
-            snprintf (url, sizeof(url), "http://%s/skyaware/", piaware_host);
-        else
-            snprintf (url, sizeof(url), "https://adsb.lol/?lat=%.3f&lon=%.3f&zoom=10",
-                        de_ll.lat_d, de_ll.lng_d);
-        openURL (url);
-        return (true);
-    }
-
-    // Windy wind icon: always present, opens windy.com centered on DE's location
-    if (inPaddedBox (s, windy_btn_b, ICON_HIT_PAD)) {
-        char url[100];
-        snprintf (url, sizeof(url), "https://www.windy.com/?%.3f,%.3f,8",
-                    de_ll.lat_d, de_ll.lng_d);
-        openURL (url);
-        return (true);
-    }
-
     if (inBox (s, auxtime_b)) {
 
         runAuxTimeMenu();
@@ -1388,10 +1245,9 @@ bool checkClockTouch (SCoord &s)
         // check a few special cases but mostly we put up a menu to allow editing time
 
         // rightmost edge of the "safe" zone for the Change Time menu: stop a few pixels
-        // before the MOTD/ADS-B/Windy icon column so a near-miss tap on any of those icons
-        // doesn't fall through into the generic handler below and pop the menu on top of
-        // them. fall back to the old 7/8 fraction if for some reason the icon column hasn't
-        // been positioned yet (motd_btn_b.x == 0).
+        // before the MOTD icon so a near-miss tap on it doesn't fall through into the
+        // generic handler below and pop the menu on top of it. fall back to the old 7/8
+        // fraction if for some reason the icon hasn't been positioned yet (motd_btn_b.x == 0).
         uint16_t safe_dx = motd_btn_b.x ? (motd_btn_b.x - clock_b.x - 3) : (7*clock_b.w/8);
 
         if (dx >= clock_b.w-UTC_W && dy <= UTC_H) {

--- a/ESPHamClock/earthmap.cpp
+++ b/ESPHamClock/earthmap.cpp
@@ -1265,6 +1265,8 @@ void initEarthMap()
     drawBordersButton();
     drawWefaxButton();
     drawFiresButton();
+    drawWindButton();
+    drawADSBBadge();
 
     // update astro info
     updateCircumstances();
@@ -1387,6 +1389,8 @@ void drawMoreEarth()
         drawBordersButton();
         drawWefaxButton();
         drawFiresButton();
+        drawWindButton();
+        drawADSBBadge();
 
         // draw now
         tft.drawPR();
@@ -1934,9 +1938,10 @@ void antipode (LatLong &to, const LatLong &from)
 }
 
 /* return whether s is over the view_btn_b, including an extra border for fat lines or DX etc.
- * also extends over the Borders and/or Fires badges, when currently shown, since they all sit
- * side by side -- Fires floats to the right of whichever of View/Borders is rightmost, so it's
- * always the last word on where the row actually ends.
+ * also extends over the Borders, Fires, WEFAX, Wind and/or ADS-B badges, when currently shown,
+ * since they all sit side by side -- each floats to the right of whichever of View/Borders/Fires/
+ * WEFAX/Wind is rightmost, so ADS-B, being last in every chain it can appear in (Countries/
+ * Terrain/Clouds' Borders+Fires row, or Weather's WEFAX+Wind row), must be checked last here too.
  */
 bool overViewBtn (const SCoord &s, uint16_t border)
 {
@@ -1946,6 +1951,12 @@ bool overViewBtn (const SCoord &s, uint16_t border)
         right_edge = borders_btn_b.x + borders_btn_b.w;
     if (firesBadgeVisible())
         right_edge = fires_btn_b.x + fires_btn_b.w;
+    if (wefaxBadgeVisible())
+        right_edge = wefax_btn_b.x + wefax_btn_b.w;
+    if (windBadgeVisible())
+        right_edge = windmap_btn_b.x + windmap_btn_b.w;
+    if (adsbBadgeVisible())
+        right_edge = adsbmap_btn_b.x + adsbmap_btn_b.w;
     return (s.x < right_edge + border && s.y < view_btn_b.y + view_btn_b.h + border);
 }
 

--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -28,6 +28,74 @@ char live_html[] =  R"_raw_html_(
             touch-action: pinch-zoom; /* allow both 1-finger moves and multi-touch p-z */
         }
 
+        /* overlay used to show an embedded page in-app (e.g. ADS-B Exchange), instead of a
+         * new tab. covers most of the canvas but leaves a visible margin so it's clearly a
+         * popup, not a navigation away from HamClock. */
+        #embed-overlay {
+            display: none;              /* toggled to flex by showEmbed() */
+            position: fixed;
+            left: 3%; top: 3%; right: 3%; bottom: 3%;
+            flex-direction: column;
+            background: #111;
+            border: 1px solid #888;
+            box-shadow: 0 0 20px rgba(0,0,0,0.7);
+            z-index: 1000;
+        }
+
+        #embed-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 6px 10px;
+            background: #222;
+            color: #eee;
+            font-family: sans-serif;
+            font-size: 14px;
+            border-bottom: 1px solid #888;
+        }
+
+        #embed-title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            flex: 1;
+        }
+
+        #embed-header button {
+            margin-left: 8px;
+            background: #333;
+            color: #eee;
+            border: 1px solid #888;
+            border-radius: 3px;
+            padding: 4px 10px;
+            font-size: 13px;
+            cursor: pointer;
+        }
+
+        #embed-header button:hover {
+            background: #444;
+        }
+
+        #embed-frame {
+            flex: 1;
+            width: 100%;
+            border: none;
+            background: white;
+        }
+
+        /* shown if the embedded site appears not to have loaded (likely blocked by the
+         * target's own framing policy) -- points the user at the manual fallback button
+         * instead of silently leaving a blank frame. */
+        #embed-fallback-note {
+            display: none;
+            padding: 6px 10px;
+            background: #442;
+            color: #fd8;
+            font-family: sans-serif;
+            font-size: 12px;
+            border-bottom: 1px solid #888;
+        }
+
     </style>
 
     <script>
@@ -361,6 +429,46 @@ char live_html[] =  R"_raw_html_(
             }
         }
 
+        // show the given url in the in-page embed overlay instead of a new tab.
+        //
+        // N.B. cross-origin iframes give JS no reliable way to detect whether the target site
+        // actually rendered or silently refused via X-Frame-Options/CSP frame-ancestors -- we
+        // can't inspect contentDocument across origins, and a refused frame still fires 'load'
+        // in most browsers. So this doesn't try to auto-detect failure and auto-redirect: an
+        // automatic window.open() from a timer callback is a non-user-gesture popup anyway and
+        // gets blocked by the browser's popup blocker in practice. Instead: the "Open in new
+        // tab" button is always visible up front, and a one-time hint banner appears a few
+        // seconds in as a nudge in case the frame is sitting blank.
+        var embed_hint_timer = null;
+        function showEmbed (url) {
+            document.getElementById ('embed-frame').src = url;
+            document.getElementById ('embed-title').textContent = url;
+            document.getElementById ('embed-fallback-note').style.display = 'none';
+            document.getElementById ('embed-overlay').style.display = 'flex';
+
+            if (embed_hint_timer)
+                clearTimeout (embed_hint_timer);
+            embed_hint_timer = setTimeout (function() {
+                document.getElementById ('embed-fallback-note').style.display = 'block';
+            }, 4000);
+        }
+
+        function hideEmbed () {
+            document.getElementById ('embed-overlay').style.display = 'none';
+            document.getElementById ('embed-frame').src = 'about:blank';   // stop it running in bg
+            if (embed_hint_timer) {
+                clearTimeout (embed_hint_timer);
+                embed_hint_timer = null;
+            }
+        }
+
+        // user gesture -- window.open() here is reliable, unlike from a timer callback
+        function embedOpenNewTab () {
+            var url = document.getElementById ('embed-frame').src;
+            window.open (url, "HamClockTab");
+            hideEmbed ();
+        }
+
         // try once to engage full screen if desired.
         // N.B. must be called from a user action
         function checkFullScreen() {
@@ -443,6 +551,31 @@ char live_html[] =  R"_raw_html_(
                         if (!window.open(url, "HamClockTab")) {         // naming the tab allows reuse
                             console.log ("Failed to open ", url);
                             alert ("Failed to open " + url + ". \nYou may have popups blocked");
+                        }
+                    }
+
+                    else if (e.data.substring(0,6) == 'embed ') {
+                        // show a url in an in-page overlay instead of a new tab
+                        var url = e.data.substring(6);
+                        console.log('embedding ' + url);
+                        showEmbed (url);
+                    }
+
+                    else if (e.data === 'paste') {
+                        if (navigator.clipboard && navigator.clipboard.readText) {
+                            navigator.clipboard.readText().then(text => {
+                                if (text)
+                                    pasteString(text);
+                            }).catch(err => {
+                                console.log("clipboard read denied: ", err);
+                                let text = prompt("Paste text here (Ctrl+V):", "");
+                                if (text)
+                                    pasteString(text);
+                            });
+                        } else {
+                            let text = prompt("Paste text here (Ctrl+V):", "");
+                            if (text)
+                                pasteString(text);
                         }
                     }
 
@@ -565,26 +698,6 @@ char live_html[] =  R"_raw_html_(
                 var button = ((event.button == 0 && mods) || event.button == 1 || event.button == 2) ? 1 : 0;
                 console.log ("button " + event.button + " + " + mods + " -> " + button);
 
-                // if tapping on virtual keyboard Paste button in non-Android browser, read browser clipboard
-                // Only trigger on primary button (left click / touch tap) without keyboard modifiers
-                if (event.button === 0 && !mods && m.x >= 16 && m.x <= 155 && m.y >= 404 && m.y <= 470 && !window.AndroidApp) {
-                    if (navigator.clipboard && navigator.clipboard.readText) {
-                        navigator.clipboard.readText().then(text => {
-                            if (text)
-                                pasteString(text);
-                        }).catch(err => {
-                            console.log("clipboard read denied: ", err);
-                            let text = prompt("Paste text here (Ctrl+V):", "");
-                            if (text)
-                                pasteString(text);
-                        });
-                    } else {
-                        let text = prompt("Paste text here (Ctrl+V):", "");
-                        if (text)
-                            pasteString(text);
-                    }
-                }
-
                 // compose and send
                 let msg = 'set_touch?x=' + m.x + '&y=' + m.y + '&button=' + button;
                 sendWSMsg (msg);
@@ -653,6 +766,19 @@ char live_html[] =  R"_raw_html_(
 
     <!-- page is a single canvas, size will be set based on hamclock build size -->
     <canvas id='hamclock-cvs'></canvas>
+
+    <!-- in-page overlay for embedded links (e.g. ADS-B badge), toggled by showEmbed()/hideEmbed() -->
+    <div id='embed-overlay'>
+        <div id='embed-header'>
+            <span id='embed-title'></span>
+            <button onclick='embedOpenNewTab()'>Open in new tab &#8599;</button>
+            <button onclick='hideEmbed()'>&#10005; Close</button>
+        </div>
+        <div id='embed-fallback-note'>
+            Taking a while to load? This site may not allow embedding -- try "Open in new tab" above.
+        </div>
+        <iframe id='embed-frame'></iframe>
+    </div>
 
 </body>
 </html> 

--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -346,6 +346,16 @@ char live_html[] =  R"_raw_html_(
                 return;
             }
 
+            // Escape key closes embed overlay if open
+            if (key === "Escape") {
+                var overlay = document.getElementById ('embed-overlay');
+                if (overlay && overlay.style.display !== 'none') {
+                    hideEmbed();
+                    event.preventDefault();
+                    return;
+                }
+            }
+
             // don't let browser see tab
             if (key === "Tab") {
                 if (event_verbose)
@@ -451,6 +461,12 @@ char live_html[] =  R"_raw_html_(
             embed_hint_timer = setTimeout (function() {
                 document.getElementById ('embed-fallback-note').style.display = 'block';
             }, 4000);
+
+            var closeBtn = document.getElementById ('embed-close-btn');
+            if (closeBtn)
+                closeBtn.focus();
+            if (window.AndroidApp && window.AndroidApp.setEmbedVisible)
+                window.AndroidApp.setEmbedVisible(true);
         }
 
         function hideEmbed () {
@@ -460,6 +476,8 @@ char live_html[] =  R"_raw_html_(
                 clearTimeout (embed_hint_timer);
                 embed_hint_timer = null;
             }
+            if (window.AndroidApp && window.AndroidApp.setEmbedVisible)
+                window.AndroidApp.setEmbedVisible(false);
         }
 
         // user gesture -- window.open() here is reliable, unlike from a timer callback
@@ -771,8 +789,8 @@ char live_html[] =  R"_raw_html_(
     <div id='embed-overlay'>
         <div id='embed-header'>
             <span id='embed-title'></span>
-            <button onclick='embedOpenNewTab()'>Open in new tab &#8599;</button>
-            <button onclick='hideEmbed()'>&#10005; Close</button>
+            <button id='embed-open-btn' onclick='embedOpenNewTab()'>Open in new tab &#8599;</button>
+            <button id='embed-close-btn' onclick='hideEmbed()'>&#10005; Close</button>
         </div>
         <div id='embed-fallback-note'>
             Taking a while to load? This site may not allow embedding -- try "Open in new tab" above.

--- a/ESPHamClock/liveweb.cpp
+++ b/ESPHamClock/liveweb.cpp
@@ -46,6 +46,9 @@ const int liveweb_maxmax = MAX_CLIENTS-1;               // max max for -help
 // record client and possible URL for it to display.
 static ws_cli_conn_t *lastest_ws_touch_client;          // most recent client performing set_touch
 static char *liveweb_openurl;                           // malloced url to attempt to open, else NULL
+static bool liveweb_openurl_embed;                       // true if liveweb_openurl should be shown
+                                                          // in the in-page overlay instead of a new tab
+static bool liveweb_dopaste;                            // client should attempt paste
 static pthread_mutex_t lw_url_lock = PTHREAD_MUTEX_INITIALIZER; // thread-safe access for liveweb_openurl
 
 
@@ -432,14 +435,16 @@ static void sendFullScreen(ws_cli_conn_t *client)
     ws_sendframe_txt (client, "full-screen");
 }
 
-/* send message to open a url.
+/* send message to open a url, either as a new tab or, if embed is set, in the client's in-page
+ * embed overlay (see showEmbed() in liveweb-html.cpp).
  * N.B. coordinate with liveweb-html
  */
-static void sendURL (ws_cli_conn_t *client, const char *url)
+static void sendURL (ws_cli_conn_t *client, const char *url, bool embed)
 {
-    StackMalloc opencmd_mem(strlen(url)+50);
+    const char *verb = embed ? "embed " : "open ";
+    StackMalloc opencmd_mem(strlen(url)+strlen(verb)+1);
     char *opencmd = (char *)opencmd_mem.getMem();
-    snprintf (opencmd, opencmd_mem.getSize(), "open %s", url);
+    snprintf (opencmd, opencmd_mem.getSize(), "%s%s", verb, url);
     ws_sendframe_txt (client, opencmd);
 }
 
@@ -469,16 +474,22 @@ static void getLiveUpdate (ws_cli_conn_t *client, char args[], size_t args_len)
     if (liveweb_fs_ready && getWebFullScreen())
         sendFullScreen (client);
 
-    // check for pending openurl if this client did a touch
+    // check for pending openurl or paste if this client did a touch
     pthread_mutex_lock (&lw_url_lock);
     if (lastest_ws_touch_client == client) {
+        if (liveweb_dopaste) {
+            Serial.printf ("LIVE: sending paste command\n");
+            ws_sendframe_txt (client, "paste");
+            liveweb_dopaste = false;
+        }
         if (liveweb_openurl) {
-            Serial.printf ("LIVE: sending URL %s\n", liveweb_openurl);
-            sendURL (client, liveweb_openurl);
+            Serial.printf ("LIVE: sending URL %s (embed=%d)\n", liveweb_openurl, liveweb_openurl_embed);
+            sendURL (client, liveweb_openurl, liveweb_openurl_embed);
             free (liveweb_openurl);
             liveweb_openurl = NULL;
-            lastest_ws_touch_client = NULL;
+            liveweb_openurl_embed = false;
         }
+        lastest_ws_touch_client = NULL;
     }
     pthread_mutex_unlock (&lw_url_lock);
 
@@ -1001,7 +1012,41 @@ void openLiveWebURL (const char *url)
         free (liveweb_openurl);
     }
     liveweb_openurl = strdup (url);
+    liveweb_openurl_embed = false;
     Serial.printf ("LIVE: live web staging URL %s\n", url);
+    pthread_mutex_unlock (&lw_url_lock);
+}
+
+/* same as openLiveWebURL() but asks the client to show it in its in-page embed overlay (an
+ * iframe) instead of opening a new tab -- see showEmbed() in liveweb-html.cpp. Intended for
+ * pages worth glancing at without leaving HamClock's tab. Not every site allows this -- some set
+ * X-Frame-Options/CSP frame-ancestors specifically to block being framed by another site (eg
+ * confirmed: Windy.com, which is why windbadge.cpp does NOT use this) -- so only call this for a
+ * target confirmed to permit framing; the client shows a manual "Open in new tab" fallback for
+ * the case it doesn't, since that failure can't be reliably detected across origins from JS.
+ */
+void openLiveWebURLEmbedded (const char *url)
+{
+    pthread_mutex_lock (&lw_url_lock);
+    if (liveweb_openurl) {
+        Serial.printf ("LIVE: discarded late URL %s\n", liveweb_openurl);
+        free (liveweb_openurl);
+    }
+    liveweb_openurl = strdup (url);
+    liveweb_openurl_embed = true;
+    Serial.printf ("LIVE: live web staging embedded URL %s\n", url);
+    pthread_mutex_unlock (&lw_url_lock);
+}
+
+/* record desire for most recent touch client to paste from clipboard.
+ */
+void requestLiveWebPaste (void)
+{
+    pthread_mutex_lock (&lw_url_lock);
+    if (lastest_ws_touch_client) {
+        liveweb_dopaste = true;
+        Serial.printf ("LIVE: live web staging paste request\n");
+    }
     pthread_mutex_unlock (&lw_url_lock);
 }
 

--- a/ESPHamClock/qrz.cpp
+++ b/ESPHamClock/qrz.cpp
@@ -44,9 +44,112 @@ void openQRZBio (const DXSpot &s)
     char url[200];
     snprintf (url, sizeof(url), "%.*s%s", (int)(call_start-url_template), url_template, call_uc);
 
-    // open
+    // open. all four providers were tested directly (a standalone <iframe> pointed at each): qrz.com
+    // blocks framing outright (Firefox refuses to render it, showing its own error in the frame's
+    // place), the other three don't -- so only qrz.com is held back from the Live Web embed.
     Serial.printf ("QRZ: opening %s\n", url);
+    if (qid == QRZ_QRZ)
+        openURLPopup (url);
+    else
+        openURLPopupEmbed (url);
+}
+
+/* like openURL(), but on the X11 desktop build, try to open the page as a chromeless Chromium
+ * "app mode" popup positioned near the HamClock window, instead of a normal browser tab -- the
+ * closest thing to an embedded browser achievable without linking a new dependency (CEF,
+ * WebKitGTK, etc), since Chromium already ships by default on Raspberry Pi OS. Everywhere else
+ * (fb0 -- no windowing layer to pop over; ESP32; Android; Live Web; or if no Chromium build is
+ * found) this is the same as openURL().
+ *
+ * N.B. this launches a genuinely separate top-level window, just an undecorated, sized, and
+ * positioned one -- there's no way to draw a second application's rendering inside HamClock's own
+ * window without linking an embeddable browser engine. Live Web is the one place a true in-page
+ * embed (an <iframe>) is possible, since that already runs inside a real browser tab -- but
+ * whether it actually renders depends entirely on the target site's own X-Frame-Options/CSP
+ * frame-ancestors policy: some sites (confirmed: Windy.com) block being framed by another site
+ * outright, others (confirmed: ADS-B Exchange's globe map) allow it. Since that's a per-site
+ * fact, not something generic, plain openURLPopup() never tries to embed -- see
+ * openURLPopupEmbed() for the variant used by callers who've confirmed their target allows it.
+ */
+void openURLPopup (const char *url)
+{
+#if defined(_USE_X11)
+
+    // Live Web already runs inside a real browser tab; just open a new one there, same as
+    // openURL() -- see openURLPopupEmbed() if the target is known to allow framing
+    if (isLiveWebTouch()) {
+        openURL (url);
+        return;
+    }
+
+    // find a Chromium build on PATH; try the common names in order
+    static const char *chromium_names[] = { "chromium-browser", "chromium", "google-chrome" };
+    const char *chromium = NULL;
+    for (size_t i = 0; i < sizeof(chromium_names)/sizeof(chromium_names[0]); i++) {
+        char which_cmd[100];
+        snprintf (which_cmd, sizeof(which_cmd), "which %s >/dev/null 2>&1", chromium_names[i]);
+        if (system (which_cmd) == 0) {
+            chromium = chromium_names[i];
+            break;
+        }
+    }
+
+    if (chromium) {
+        // default popup size, capped to something reasonable; position just inside the
+        // HamClock window's own top-left corner if we can find it, else let the WM decide
+        int popup_w = 900, popup_h = 650;
+        int pos_x = -1, pos_y = -1;
+        int wx, wy, ww, wh;
+        if (tft.getWinScreenGeom (&wx, &wy, &ww, &wh)) {
+            pos_x = wx + 40;
+            pos_y = wy + 40;
+        }
+
+        StackMalloc cmd_mem (strlen(url) + strlen(chromium) + 150);
+        char *cmd = (char *) cmd_mem.getMem();
+        if (pos_x >= 0)
+            snprintf (cmd, cmd_mem.getSize(),
+                "%s --app=%s --window-size=%d,%d --window-position=%d,%d >/dev/null 2>&1 &",
+                chromium, url, popup_w, popup_h, pos_x, pos_y);
+        else
+            snprintf (cmd, cmd_mem.getSize(),
+                "%s --app=%s --window-size=%d,%d >/dev/null 2>&1 &", chromium, url, popup_w, popup_h);
+
+        if ((system (cmd) >> 8) != 0)
+            Serial.printf ("URL popup: fail: %s\n", cmd);
+        else
+            Serial.printf ("URL popup: ok: %s\n", cmd);
+        return;
+    }
+
+    // no Chromium found -- fall back to the normal system browser
     openURL (url);
+
+#else
+
+    // fb0 has no windowing layer to pop a second window into; ESP32/Android have no
+    // desktop-browser concept at all; Live Web is handled by openURLPopupEmbed() if the
+    // caller wants embedding, else falls through to openURL() same as the X11 branch above
+    openURL (url);
+
+#endif
+}
+
+/* same as openURLPopup(), except a Live Web touch gets the in-page <iframe> overlay instead of a
+ * plain new tab -- only call this for a target confirmed to allow being framed (see the N.B. on
+ * openURLPopup() above; ADS-B Exchange's globe map is confirmed to allow it, Windy.com is
+ * confirmed NOT to, which is why windbadge.cpp uses openURLPopup() instead of this).
+ * on the X11 desktop build, local (non-Live-Web) touches still get the Chromium popup, same as
+ * openURLPopup() -- that path was never affected by framing headers either way, since it opens a
+ * genuine top-level window, not a frame.
+ */
+void openURLPopupEmbed (const char *url)
+{
+    if (isLiveWebTouch()) {
+        openLiveWebURLEmbedded (url);
+        return;
+    }
+    openURLPopup (url);
 }
 
 /* attempt to open the given web page in a new browser tab.

--- a/ESPHamClock/setup.cpp
+++ b/ESPHamClock/setup.cpp
@@ -510,7 +510,7 @@ static StringPrompt string_pr[N_SPR] = {
 
     {2, {310, R2Y3(3), 130, PR_H}, {452, R2Y3(3), 208, PR_H}, "PiAware host:", piaware_host, NV_PIAWAREHOST_LEN, 0, 0,
                 "Enter the IP address or DNS host name of a local PiAware ADS-B receiver to use for the "
-                "ADS-B airplane icon instead of adsb.lol; leave blank to use adsb.lol"},
+                "ADS-B airplane icon instead of ADS-B Exchange; leave blank to use ADS-B Exchange"},
 
     {2, {100, R2Y3(4), 60, PR_H}, {160, R2Y3(4), 580, PR_H}, "file:", adif_fn, NV_ADIFFN_LEN, 0, 0,
                 "Enter the path name to the ADIF file; "
@@ -5313,6 +5313,7 @@ static void runSetup()
                         checkLLGEdit (sp);
                 } else {
                     tft.pasteClipboard();
+                    requestLiveWebPaste();
                 }
                 wdDelay (150);
                 drawStringInBox ("Paste", paste_b, false, RA8875_CYAN);

--- a/ESPHamClock/windbadge.cpp
+++ b/ESPHamClock/windbadge.cpp
@@ -1,0 +1,72 @@
+/* windbadge.cpp -- on-map "Wind" badge for HamClock
+ *
+ * Same idea as adsbbadge.cpp: no on/off state of its own, draws nothing onto the map, just a
+ * link button. Tapping it opens Windy.com centered on DE via openURLPopup() -- a Chromium
+ * app-mode popup on the X11 desktop build, or a plain new browser tab everywhere else -- see
+ * qrz.cpp.
+ *
+ * On-map presence, not buried in the map menu: only shown when core_map == CM_WX (the "Weather"
+ * core map style, ie the one people actually think to look for wind info on), same convention as
+ * wefaxBadgeVisible(). It floats to the right of the WEFAX badge, which shares the row on CM_WX
+ * and can be showing at the same time, or right of View when WEFAX isn't enabled.
+ */
+
+#include "HamClock.h"
+
+SBox windmap_btn_b;                    // extern; badge box, geometry set each draw (floats with WEFAX)
+
+/* return whether the on-map "Wind" badge should currently be shown.
+ * Weather map only -- no projection restriction, matching WEFAX's own simplicity, since this is
+ * just a link and draws nothing that would look wrong in an azimuthal projection.
+ */
+bool windBadgeVisible(void)
+{
+    return (core_map == CM_WX);
+}
+
+/* draw (or blank) the on-map "Wind" badge.
+ * Floats to the right of the WEFAX badge, when showing, else right of View -- recomputed here
+ * every draw, same convention as drawFiresButton()/drawADSBBadge() tracking their neighbors.
+ */
+void drawWindButton(void)
+{
+    windmap_btn_b.y = view_btn_b.y;
+
+    if (!windBadgeVisible()) {
+        // wrong core map -- leave the map pixels already painted here alone.
+        return;
+    }
+
+    const int gap = 4;
+    const int pad = 8;
+    selectFontStyle (LIGHT_FONT, FAST_FONT);
+    uint16_t left_edge = wefaxBadgeVisible() ? (wefax_btn_b.x + wefax_btn_b.w)
+                                              : (view_btn_b.x + view_btn_b.w);
+    windmap_btn_b.x = left_edge + gap;
+    windmap_btn_b.w = getTextWidth ("Wind") + pad;
+    windmap_btn_b.h = view_btn_b.h;
+
+    // always the same "unpressed" look -- black fill, white outline/text -- since it has no
+    // on/off state, just Borders/Fires' normal (off) styling permanently.
+    tft.fillRect (windmap_btn_b.x, windmap_btn_b.y, windmap_btn_b.w-1, windmap_btn_b.h-1, RA8875_BLACK);
+    tft.drawRect (windmap_btn_b.x, windmap_btn_b.y, windmap_btn_b.w-1, windmap_btn_b.h-1, RA8875_WHITE);
+
+    const char *label = "Wind";
+    uint16_t lbl_w = getTextWidth(label);
+    tft.setCursor (windmap_btn_b.x+(windmap_btn_b.w-lbl_w)/2, windmap_btn_b.y+2);
+    tft.setTextColor (RA8875_WHITE);
+    tft.print (label);
+}
+
+/* open Windy.com centered on DE.
+ * uses openURLPopup(): on the X11 desktop build this is a chromeless Chromium app-mode popup
+ * positioned near the HamClock window; everywhere else (Live Web, fb0, ESP32, Android, or no
+ * Chromium found) it's a plain new browser tab -- see qrz.cpp.
+ * call this from checkTouch() when windBadgeVisible() && inBox(s, windmap_btn_b).
+ */
+void windBadgeClicked(void)
+{
+    char url[100];
+    snprintf (url, sizeof(url), "https://www.windy.com/?%.3f,%.3f,8", de_ll.lat_d, de_ll.lng_d);
+    openURLPopup (url);
+}

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -18,19 +18,19 @@ include_directories(
     ${HC_DIR}/zlib-hc
 )
 
-file(GLOB HC_SRCS
+file(GLOB HC_SRCS CONFIGURE_DEPENDS
     "${HC_DIR}/*.cpp"
 )
 
-file(GLOB ARDUINO_SRCS
+file(GLOB ARDUINO_SRCS CONFIGURE_DEPENDS
     "${HC_DIR}/ArduinoLib/*.cpp"
 )
 
-file(GLOB WS_SRCS
+file(GLOB WS_SRCS CONFIGURE_DEPENDS
     "${HC_DIR}/wsServer/src/*.cpp"
 )
 
-file(GLOB ZLIB_SRCS
+file(GLOB ZLIB_SRCS CONFIGURE_DEPENDS
     "${HC_DIR}/zlib-hc/*.cpp"
 )
 

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -82,6 +82,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var statusText: TextView
     private lateinit var btnSettings: ImageButton
+    @Volatile private var isEmbedVisible = false
 
     private val executor = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -440,6 +441,7 @@ class MainActivity : AppCompatActivity() {
             setSupportZoom(false)
             javaScriptCanOpenWindowsAutomatically = true
             setSupportMultipleWindows(true)
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
         }
 
         webView.setLayerType(View.LAYER_TYPE_HARDWARE, null)
@@ -451,6 +453,12 @@ class MainActivity : AppCompatActivity() {
                 mainHandler.post {
                     openExternalUrl(url)
                 }
+            }
+
+            @JavascriptInterface
+            fun setEmbedVisible(visible: Boolean) {
+                isEmbedVisible = visible
+                Log.i(TAG, "isEmbedVisible updated: $visible")
             }
 
             @JavascriptInterface
@@ -804,6 +812,16 @@ class MainActivity : AppCompatActivity() {
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         if (event.action == KeyEvent.ACTION_DOWN) {
+            if (event.keyCode == KeyEvent.KEYCODE_BACK && isEmbedVisible) {
+                webView.evaluateJavascript("if (typeof hideEmbed === 'function') hideEmbed();", null)
+                return true
+            }
+
+            if (isEmbedVisible) {
+                // When embed overlay is showing, allow standard WebView focus navigation for D-pad and Enter
+                return super.dispatchKeyEvent(event)
+            }
+
             when (event.keyCode) {
                 KeyEvent.KEYCODE_MENU -> {
                     showBackendSettingsDialog()


### PR DESCRIPTION
Taking wasatch-dev's branch and adding resolution for android builds:

Fix Android build and UX issues for iframe popups
- Add CONFIGURE_DEPENDS to CMakeLists.txt to automatically detect new C++ sources
- Intercept Back button in MainActivity to dismiss embed overlay without closing app
- Delegate D-pad navigation to WebView when overlay is active and autofocus Close button
- Support Escape key in liveweb-html to dismiss embed overlay
- Allow mixed content in Android WebView for local/remote embedded frames