### PR TITLE
ci: advance Play Store upload to completed status and suppress punycode warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,16 +155,18 @@ jobs:
             echo "Edge build or notes file not found - skipping release notes"
           fi
 
-      # Upload the signed .aab as a Draft to Google Play console (Alpha track)
-      - name: Upload to Google Play Alpha Track as Draft
+      # Upload the signed .aab to Google Play console (Alpha track)
+      - name: Upload to Google Play Alpha Track
         if: ${{ github.event_name == 'push' || inputs.push_play_store == true || inputs.push_play_store == 'true' }}
         uses: r0adkll/upload-google-play@v1
+        env:
+          NODE_OPTIONS: --no-deprecation
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_JSON_KEY }}
           packageName: org.openhamclock.hamclock
           releaseFiles: dist/org.openhamclock*.aab
           tracks: alpha
-          status: draft
+          status: completed
           whatsNewDirectory: dist/whatsnew
           mappingFile: dist/mapping.txt
           debugSymbols: dist/native-debug-symbols.zip

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,7 @@ gh workflow run
 | `tag_name` | string | `v0.0.0` | Version tag to release (e.g., `v4.32.0` or `v4.32b00.0`). |
 | `publish_release` | choice (`true`, `false`) | `true` | When `true`, publishes the release immediately. Set to `false` to create as a draft. |
 | `build_docker` | choice (`true`, `false`) | `true` | When `true`, builds and pushes the multi-platform Docker image. |
-| `push_play_store` | choice (`true`, `false`) | `true` | When `true`, uploads the Android AAB to Google Play (Alpha track) as a draft. |
+| `push_play_store` | choice (`true`, `false`) | `true` | When `true`, uploads the Android AAB to Google Play (Alpha track). |
 
 ### Monitoring the Workflow
 
@@ -191,7 +191,7 @@ The release workflow executes two jobs sequentially: `release` followed by `dock
 3. **Android Build & Google Play Upload:**
    - Runs `./gradlew assembleRelease bundleRelease` with JDK 17.
    - Outputs release `.apk` (direct install) and `.aab` (Google Play Store bundle).
-   - *(Optional - enabled by default)* Prepares `whatsnew` notes and uploads the `.aab` to Google Play Console (Alpha track) as a draft. Can be skipped by setting `-f push_play_store=false`.
+    - *(Optional - enabled by default)* Prepares `whatsnew` notes and uploads the `.aab` to Google Play Console (Alpha track). With Managed Publishing enabled in Play Console, changes land in the Publishing Overview for review checks. Can be skipped by setting `-f push_play_store=false`.
 4. **GitHub Release Publication:**
    - Creates the GitHub Release via `gh release create`. By default creates an active, published release; can be created as a draft using `-f publish_release=false`.
    - Generates release notes automatically from commit log (`--generate-notes`).


### PR DESCRIPTION
### Summary of Changes

1. **Suppress punycode deprecation warning:**
   - Added `NODE_OPTIONS: --no-deprecation` to `r0adkll/upload-google-play@v1` step in `.github/workflows/release.yml`.
   - Silences Node 21+ `[DEP0040] punycode module is deprecated` warnings emitted during runner execution.

2. **Transition Play Store upload status from draft to completed:**
   - Updated `status: draft` to `status: completed` in `.github/workflows/release.yml`.
   - With **Managed Publishing** enabled in Google Play Console, this moves uploaded releases to Publishing Overview under *"Changes not sent for review"* / *"Ready to send for review"*, automatically kicking off *"Running quick checks for common issues"* without submitting the build to reviewers or publishing to users.
   - Updated `RELEASE.md` documentation accordingly.