### PR TITLE
Live Web click on the ADS-B badge will now reliably be recognized as …

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -106,6 +106,16 @@ static RotMsg_t rot_msg = ROTM_RSSI;
 // WiFi touch control
 TouchType wifi_tt;
 SCoord wifi_tt_s;
+bool wifi_tt_live;                     // whether the pending wifi_tt came from a Live Web client,
+                                        // set alongside wifi_tt/wifi_tt_s by setLiveTouch() and
+                                        // consumed atomically with them below in checkTouch() --
+                                        // see isLiveWebTouch() in liveweb.cpp for why this can't
+                                        // just be re-derived from lastest_ws_touch_client at the
+                                        // time a badge handler happens to ask
+bool cur_touch_live;                   // whether the touch currently being dispatched by
+                                        // checkTouch() came from a Live Web client -- this is
+                                        // what isLiveWebTouch() reports; valid only while a touch
+                                        // is being handled (set at the top of checkTouch())
 
 // set up TFT display controller RA8875 instance on hardware SPI plus reset and chip select
 #define RA8875_RESET    16
@@ -937,11 +947,17 @@ static void checkTouch()
 
     // check for remote and local touch
     if (wifi_tt != TT_NONE) {
-        // save and reset remote touch.
+        // save and reset remote touch, along with whether it came from a Live Web client --
+        // captured here in lockstep with wifi_tt/wifi_tt_s themselves rather than queried later
+        // from lastest_ws_touch_client, which a concurrent Live Web client poll can otherwise
+        // clear out from under a badge handler (eg adsbBadgeClicked()) before it gets a chance
+        // to ask -- see isLiveWebTouch() in liveweb.cpp.
         // N.B. remote touches never turn on brightness
         s = wifi_tt_s;
         tt = wifi_tt;
         wifi_tt = TT_NONE;
+        cur_touch_live = wifi_tt_live;
+        wifi_tt_live = false;
     } else {
         // check tap
         tt = readCalTouch (s);
@@ -954,6 +970,7 @@ static void checkTouch()
             drainTouch();
             return;
         }
+        cur_touch_live = false;
     }
 
     // check lock

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -3678,6 +3678,8 @@ extern TouchType checkKBWarp (SCoord &s);
 // for passing web touch command to checkTouch()
 extern TouchType wifi_tt;
 extern SCoord wifi_tt_s;
+extern bool wifi_tt_live;
+extern bool cur_touch_live;
 
 
 

--- a/ESPHamClock/liveweb.cpp
+++ b/ESPHamClock/liveweb.cpp
@@ -646,10 +646,13 @@ static void setLiveTouch (ws_cli_conn_t *client, char args[], size_t args_len)
 
         } else {
 
-            // inform checkTouch() to use wifi_tt_s; it will reset
+            // inform checkTouch() to use wifi_tt_s; it will reset.
+            // N.B. set wifi_tt_live before wifi_tt so checkTouch() can never observe wifi_tt set
+            // without also seeing wifi_tt_live already valid for it.
             int button = wa.found[2] ? atoi (wa.value[2]) : 0;
             wifi_tt_s.x = x;
             wifi_tt_s.y = y;
+            wifi_tt_live = true;
             wifi_tt = button ? TT_TAP_BX : TT_TAP;              // 0 means button 1 -- go figure
 
             // record this client as the latest to do a touch
@@ -1056,12 +1059,19 @@ void requestLiveWebPaste (void)
     pthread_mutex_unlock (&lw_url_lock);
 }
 
-/* return whether there is a pending set_touch
+/* return whether the touch currently being dispatched by checkTouch() came from a Live Web
+ * client.
+ * N.B. this used to test lastest_ws_touch_client != NULL, but that variable exists to record
+ * which client should receive a queued openurl/paste (see getLiveUpdate()) and gets cleared on
+ * that client's very next screen-update poll -- which happens continuously, many times a second,
+ * completely independently of when the main thread actually gets around to processing the touch
+ * that set it. That poll routinely lands, and clears the flag, before checkTouch() on the main
+ * thread has even called into a badge handler, so a callback like adsbBadgeClicked() could see
+ * isLiveWebTouch() go false for a touch that genuinely came from Live Web. cur_touch_live is set
+ * in lockstep with the touch itself (see setLiveTouch() and checkTouch()), so it can't race with
+ * anything: it just reflects the touch actually being handled right now.
  */
 bool isLiveWebTouch (void)
 {
-    pthread_mutex_lock (&lw_url_lock);
-    bool is_live_touch_pending = lastest_ws_touch_client != NULL;
-    pthread_mutex_unlock (&lw_url_lock);
-    return (is_live_touch_pending);
+    return (cur_touch_live);
 }

--- a/ESPHamClock/touch.cpp
+++ b/ESPHamClock/touch.cpp
@@ -105,6 +105,7 @@ void drainTouch()
 
     wifi_tt = TT_NONE;
     wifi_tt_s = {0, 0};
+    wifi_tt_live = false;
 
     bool control, shift;
     while (tft.getChar (&control, &shift) != CHAR_NONE)

--- a/ESPHamClock/webserver.cpp
+++ b/ESPHamClock/webserver.cpp
@@ -5239,14 +5239,20 @@ TouchType readCalTouchWS (SCoord &s)
     // check for read-only remote commands
     checkWebServer (true);
 
-    // return info for remote else local touch
+    // return info for remote else local touch.
+    // N.B. capture cur_touch_live here too, same as checkTouch() -- this is the other place
+    // wifi_tt gets consumed (menus, setup wizard, stopwatch), and any of those can still lead to
+    // an openURL()/openQRZBio() call down the line that asks isLiveWebTouch().
     TouchType tt;
     if (wifi_tt != TT_NONE) {
         s = wifi_tt_s;
         tt = wifi_tt;
         wifi_tt = TT_NONE;
+        cur_touch_live = wifi_tt_live;
+        wifi_tt_live = false;
     } else {
         tt = readCalTouch (s);
+        cur_touch_live = false;
     }
 
     // return event type


### PR DESCRIPTION
…a Live Web click, so it opens in your browser's embedded view only — no more surprise Chromium window popping up on the Pi