### PR TITLE
Use QR code modal for SDO and Moon movies with fb0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ eeprom
 hc.settings
 tmp/
 .agent/
+.agents/
 
 # C stuff
 *.o

--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -112,6 +112,7 @@ bool wifi_tt_live;                     // whether the pending wifi_tt came from 
                                         // see isLiveWebTouch() in liveweb.cpp for why this can't
                                         // just be re-derived from lastest_ws_touch_client at the
                                         // time a badge handler happens to ask
+bool wifi_kb_live;                     // whether the pending keyboard char came from a Live Web client
 bool cur_touch_live;                   // whether the touch currently being dispatched by
                                         // checkTouch() came from a Live Web client -- this is
                                         // what isLiveWebTouch() reports; valid only while a touch

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -3685,6 +3685,7 @@ extern TouchType checkKBWarp (SCoord &s);
 extern TouchType wifi_tt;
 extern SCoord wifi_tt_s;
 extern bool wifi_tt_live;
+extern bool wifi_kb_live;
 extern bool cur_touch_live;
 
 

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -2720,7 +2720,7 @@ extern void openURL (const char *url);
 extern void openURLPopup (const char *url);
 extern void openURLPopupEmbed (const char *url);
 extern bool showQRCodeModal (const char *url, const char *title, const char *subtitle = NULL, const char *open_lbl = NULL);
-extern void openMovieURL (const char *hc_page, const char *orig_url);
+extern void openMovieURL (const char *hc_page, const char *orig_url, const char *title = NULL);
 
 
 /*********************************************************************************************

--- a/ESPHamClock/liveweb.cpp
+++ b/ESPHamClock/liveweb.cpp
@@ -476,7 +476,7 @@ static void getLiveUpdate (ws_cli_conn_t *client, char args[], size_t args_len)
 
     // check for pending openurl or paste if this client did a touch
     pthread_mutex_lock (&lw_url_lock);
-    if (lastest_ws_touch_client == client) {
+    if (lastest_ws_touch_client == client || (lastest_ws_touch_client == NULL && client->port != liveweb_ro_port)) {
         if (liveweb_dopaste) {
             Serial.printf ("LIVE: sending paste command\n");
             ws_sendframe_txt (client, "paste");
@@ -598,6 +598,13 @@ static void setLiveChar (ws_cli_conn_t *client, char args[], size_t args_len)
         bool shift = strchr (wa.value[1], 'S') != NULL;
 
         if (c) {
+
+            // record this client as the latest active client for URL opening and mark live touch
+            pthread_mutex_lock (&lw_url_lock);
+            lastest_ws_touch_client = client;
+            pthread_mutex_unlock (&lw_url_lock);
+            cur_touch_live = true;
+            wifi_kb_live = true;
 
             // insert into getChar queue
             tft.putChar (c, ctrl, shift);

--- a/ESPHamClock/menu.cpp
+++ b/ESPHamClock/menu.cpp
@@ -1038,8 +1038,15 @@ bool waitForUser (UserInput &ui)
             return(true);
 
         ui.kb_char = tft.getChar (&ui.kb_ctrl, &ui.kb_shift);
-        if (ui.kb_char != CHAR_NONE)
+        if (ui.kb_char != CHAR_NONE) {
+            if (wifi_kb_live) {
+                cur_touch_live = true;
+                wifi_kb_live = false;
+            } else {
+                cur_touch_live = false;
+            }
             return (true);
+        }
 
         if (ui.to_ms != UI_NOTIMEOUT && timesUp (&t0, ui.to_ms))
             return (false);

--- a/ESPHamClock/moonpane.cpp
+++ b/ESPHamClock/moonpane.cpp
@@ -112,7 +112,7 @@ bool checkMoonTouch (const SCoord &s, const SBox &box)
             drawEMETool();
         }
         if (mitems[1].set)
-            openMovieURL ("/moon/movies/ap240602.html", "https://apod.nasa.gov/apod/ap240602.html");
+            openMovieURL ("/moon/movies/ap240602.html", "https://apod.nasa.gov/apod/ap240602.html", "Moon Movie");
 
         // refresh
         scheduleNewPlot (PLOT_CH_MOON);

--- a/ESPHamClock/qrmodal.cpp
+++ b/ESPHamClock/qrmodal.cpp
@@ -41,12 +41,22 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
     int border = 8;                        // quiet zone in pixels
     int qr_px = qr_size * scale;
     int qr_box_w = qr_px + 2 * border;
+    // If running on fb0 directly without a desktop browser, can_open_browser is only true for Live Web
+    bool can_open_browser = true;
+#if defined(_USE_FB0)
+    if (!isLiveWebTouch())
+        can_open_browser = false;
+#endif
 
-    // Font metrics for sizing\n    selectFontStyle (BOLD_FONT, FAST_FONT);
+    const char *display_subtitle = subtitle;
+    if (!can_open_browser && subtitle && strstr(subtitle, "open below"))
+        display_subtitle = "Scan with phone or tablet";
+
+    // Font metrics for sizing
+    selectFontStyle (BOLD_FONT, FAST_FONT);
     uint16_t title_w = getTextWidth ((char*)title);
     selectFontStyle (LIGHT_FONT, FAST_FONT);
-    uint16_t sub_w = subtitle ? getTextWidth ((char*)subtitle) : 0;
-
+    uint16_t sub_w = display_subtitle ? getTextWidth ((char*)display_subtitle) : 0;
     // Dialog layout: accommodate QR code and text widths
     int dlg_w = qr_box_w + 30;
     if (dlg_w < title_w + 24)
@@ -93,11 +103,11 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
     tft.print (title);
 
     // Subtitle (if provided)
-    if (subtitle) {
+    if (display_subtitle) {
         selectFontStyle (LIGHT_FONT, FAST_FONT);
         tft.setTextColor (GRAY);
         tft.setCursor (dlg_b.x + (dlg_w - sub_w) / 2, dlg_b.y + pad + title_h + pad/2);
-        tft.print (subtitle);
+        tft.print (display_subtitle);
     }
 
     // QR Code container (white quiet zone background)
@@ -116,51 +126,79 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
         }
     }
 
-    // Buttons: Left button (open/action), Right button ("Close")
+    // Buttons:
+    // If can_open_browser is false (e.g. standalone fb0 without Live Web), display a single centered "Close" button.
+    // Otherwise, display Left button (Open action) and Right button ("Close").
     int btn_margin = 10;
-    int btn_gap = 8;
-    int avail_w = dlg_w - 2 * btn_margin - btn_gap;
-    int open_btn_w = avail_w / 2;
-    int close_btn_w = avail_w - open_btn_w;
     int btn_y = qr_y0 + qr_box_w + pad;
 
-    SBox open_b;
-    open_b.x = dlg_b.x + btn_margin;
-    open_b.y = btn_y;
-    open_b.w = open_btn_w;
-    open_b.h = btn_h;
+    SBox open_b = {0, 0, 0, 0};
+    SBox close_b = {0, 0, 0, 0};
 
-    SBox close_b;
-    close_b.x = open_b.x + open_b.w + btn_gap;
-    close_b.y = btn_y;
-    close_b.w = close_btn_w;
-    close_b.h = btn_h;
+    if (can_open_browser) {
+        int btn_gap = 8;
+        int avail_w = dlg_w - 2 * btn_margin - btn_gap;
+        int open_btn_w = avail_w / 2;
+        int close_btn_w = avail_w - open_btn_w;
+
+        open_b.x = dlg_b.x + btn_margin;
+        open_b.y = btn_y;
+        open_b.w = open_btn_w;
+        open_b.h = btn_h;
+
+        close_b.x = open_b.x + open_b.w + btn_gap;
+        close_b.y = btn_y;
+        close_b.w = close_btn_w;
+        close_b.h = btn_h;
+    } else {
+        // Single centered Close button
+        int close_btn_w = dlg_w - 2 * btn_margin;
+        if (close_btn_w > 120)
+            close_btn_w = 120;
+
+        close_b.x = dlg_b.x + (dlg_w - close_btn_w) / 2;
+        close_b.y = btn_y;
+        close_b.w = close_btn_w;
+        close_b.h = btn_h;
+    }
 
     auto drawModalButtons = [&] (bool open_active) {
-        // Open/action button
-        fillSBox (open_b, open_active ? RGB565(30, 80, 150) : RGB565(40, 40, 40));
-        drawSBox (open_b, open_active ? RA8875_WHITE : GRAY);
-        selectFontStyle (BOLD_FONT, FAST_FONT);
-        tft.setTextColor (RA8875_WHITE);
-        uint16_t ow = getTextWidth ((char*)open_lbl);
-        tft.setCursor (open_b.x + (open_b.w - ow) / 2, open_b.y + (btn_h - 8) / 2);
-        tft.print (open_lbl);
+        if (can_open_browser) {
+            // Open/action button
+            fillSBox (open_b, open_active ? RGB565(30, 80, 150) : RGB565(40, 40, 40));
+            drawSBox (open_b, open_active ? RA8875_WHITE : GRAY);
+            selectFontStyle (BOLD_FONT, FAST_FONT);
+            tft.setTextColor (RA8875_WHITE);
+            uint16_t ow = getTextWidth ((char*)open_lbl);
+            tft.setCursor (open_b.x + (open_b.w - ow) / 2, open_b.y + (btn_h - 8) / 2);
+            tft.print (open_lbl);
 
-        // Close button
-        fillSBox (close_b, !open_active ? RGB565(30, 80, 150) : RGB565(40, 40, 40));
-        drawSBox (close_b, !open_active ? RA8875_WHITE : GRAY);
-        selectFontStyle (BOLD_FONT, FAST_FONT);
-        tft.setTextColor (RA8875_WHITE);
-        const char *close_lbl = "Close";
-        uint16_t cw = getTextWidth ((char*)close_lbl);
-        tft.setCursor (close_b.x + (close_b.w - cw) / 2, close_b.y + (btn_h - 8) / 2);
-        tft.print (close_lbl);
+            // Close button
+            fillSBox (close_b, !open_active ? RGB565(30, 80, 150) : RGB565(40, 40, 40));
+            drawSBox (close_b, !open_active ? RA8875_WHITE : GRAY);
+            selectFontStyle (BOLD_FONT, FAST_FONT);
+            tft.setTextColor (RA8875_WHITE);
+            const char *close_lbl = "Close";
+            uint16_t cw = getTextWidth ((char*)close_lbl);
+            tft.setCursor (close_b.x + (close_b.w - cw) / 2, close_b.y + (btn_h - 8) / 2);
+            tft.print (close_lbl);
+        } else {
+            // Single Close button, styled highlighted/active
+            fillSBox (close_b, RGB565(30, 80, 150));
+            drawSBox (close_b, RA8875_WHITE);
+            selectFontStyle (BOLD_FONT, FAST_FONT);
+            tft.setTextColor (RA8875_WHITE);
+            const char *close_lbl = "Close";
+            uint16_t cw = getTextWidth ((char*)close_lbl);
+            tft.setCursor (close_b.x + (close_b.w - cw) / 2, close_b.y + (btn_h - 8) / 2);
+            tft.print (close_lbl);
+        }
 
         if (boxesOverlap (dlg_b, map_b))
             tft.drawPR();
     };
 
-    bool open_focused = true;
+    bool open_focused = can_open_browser;
     drawModalButtons (open_focused);
 
     // User input loop
@@ -176,19 +214,21 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
     bool open_confirmed = false;
     while (waitForUser (ui)) {
         if (ui.kb_char == CHAR_TAB || ui.kb_char == CHAR_LEFT || ui.kb_char == CHAR_RIGHT) {
-            open_focused = !open_focused;
-            drawModalButtons (open_focused);
+            if (can_open_browser) {
+                open_focused = !open_focused;
+                drawModalButtons (open_focused);
+            }
             continue;
         }
         if (ui.kb_char == CHAR_CR || ui.kb_char == CHAR_NL || ui.kb_char == ' ') {
-            open_confirmed = open_focused;
+            open_confirmed = can_open_browser && open_focused;
             break;
         }
         if (ui.kb_char == CHAR_ESC) {
             open_confirmed = false;
             break;
         }
-        if (inBox (ui.tap, open_b)) {
+        if (can_open_browser && inBox (ui.tap, open_b)) {
             open_confirmed = true;
             break;
         }

--- a/ESPHamClock/qrmodal.cpp
+++ b/ESPHamClock/qrmodal.cpp
@@ -42,11 +42,12 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
     int qr_px = qr_size * scale;
     int qr_box_w = qr_px + 2 * border;
     // Check if browser opening is supported
-#if defined(_USE_FB0)
-    // On standalone fb0 there is no window manager or browser
-    bool can_open_browser = false;
-#else
+    bool is_live_session = isLiveWebTouch();
     bool can_open_browser = true;
+#if defined(_USE_FB0)
+    // On standalone fb0 there is no window manager or browser unless accessed via Live Web
+    if (!is_live_session)
+        can_open_browser = false;
 #endif
 
     const char *display_subtitle = subtitle;
@@ -214,6 +215,8 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
 
     bool open_confirmed = false;
     while (waitForUser (ui)) {
+        if (isLiveWebTouch())
+            is_live_session = true;
         if (ui.kb_char == CHAR_TAB || ui.kb_char == CHAR_LEFT || ui.kb_char == CHAR_RIGHT) {
             if (can_open_browser) {
                 open_focused = !open_focused;
@@ -254,7 +257,9 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
         tft.drawPR();
 
     if (open_confirmed) {
-        Serial.printf ("QRModal: opening %s\n", url);
+        Serial.printf ("QRModal: opening %s (is_live=%d)\n", url, is_live_session);
+        if (is_live_session)
+            cur_touch_live = true;
         openURLPopup (url);
     }
 

--- a/ESPHamClock/qrmodal.cpp
+++ b/ESPHamClock/qrmodal.cpp
@@ -41,11 +41,12 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
     int border = 8;                        // quiet zone in pixels
     int qr_px = qr_size * scale;
     int qr_box_w = qr_px + 2 * border;
-    // If running on fb0 directly without a desktop browser, can_open_browser is only true for Live Web
-    bool can_open_browser = true;
+    // Check if browser opening is supported
 #if defined(_USE_FB0)
-    if (!isLiveWebTouch())
-        can_open_browser = false;
+    // On standalone fb0 there is no window manager or browser
+    bool can_open_browser = false;
+#else
+    bool can_open_browser = true;
 #endif
 
     const char *display_subtitle = subtitle;
@@ -221,7 +222,11 @@ bool showQRCodeModal (const char *url, const char *title, const char *subtitle, 
             continue;
         }
         if (ui.kb_char == CHAR_CR || ui.kb_char == CHAR_NL || ui.kb_char == ' ') {
-            open_confirmed = can_open_browser && open_focused;
+            // Select currently highlighted choice
+            if (can_open_browser)
+                open_confirmed = open_focused;
+            else
+                open_confirmed = false;     // Only "Close" button exists, so selecting it closes
             break;
         }
         if (ui.kb_char == CHAR_ESC) {

--- a/ESPHamClock/sdo.cpp
+++ b/ESPHamClock/sdo.cpp
@@ -272,10 +272,12 @@ bool updateSDOPane (const SBox &box)
 static void showSDOmovie (void)
 {
     char hc_page[256];
+    char title[64];
 
     snprintf (hc_page, sizeof(hc_page), "/SDO/movies/%s", sdo_filenames[sdo_choice]);
+    snprintf (title, sizeof(title), "SDO %s Movie", sdo_menu[sdo_choice]);
 
-    openMovieURL (hc_page, sdo_url[sdo_choice]);
+    openMovieURL (hc_page, sdo_url[sdo_choice], title);
 }
 
 /* check for our touch in the given pane box.
@@ -320,12 +322,8 @@ bool checkSDOTouch (const SCoord &s, const SBox &box)
     // set grayline option
     mitems[SDOM_GRAYLINE] = {MENU_TOGGLE, false, 2, SM_INDENT, "Grayline tool", 0};
 
-    // set show web page option, but not on fb0
-#if defined(_USE_FB0)
-    mitems[SDOM_SHOWWEB] = {MENU_IGNORE, false, 0, 0, NULL};
-#else
+    // set show movie option (supported on all platforms via QR code)
     mitems[SDOM_SHOWWEB] = {MENU_TOGGLE, false, 3, SM_INDENT, "Show movie", 0};
-#endif
 
     SBox menu_b = box;          // copy, not ref
     menu_b.x += box.w/4;

--- a/ESPHamClock/touch.cpp
+++ b/ESPHamClock/touch.cpp
@@ -166,6 +166,7 @@ void drainTouch()
     wifi_tt = TT_NONE;
     wifi_tt_s = {0, 0};
     wifi_tt_live = false;
+    wifi_kb_live = false;
 
     bool control, shift;
     while (tft.getChar (&control, &shift) != CHAR_NONE)

--- a/ESPHamClock/wifi.cpp
+++ b/ESPHamClock/wifi.cpp
@@ -1601,7 +1601,7 @@ bool httpSkipHeader (WiFiClient &client)
  * If 404 (or connecting fails), open orig_url.
  * Otherwise open backend URL.
  */
-void openMovieURL (const char *hc_page, const char *orig_url)
+void openMovieURL (const char *hc_page, const char *orig_url, const char *title)
 {
     WiFiClient client;
     bool is_404 = false;
@@ -1619,14 +1619,15 @@ void openMovieURL (const char *hc_page, const char *orig_url)
         is_404 = true;
     }
 
-    if (is_404) {
-        openURL (orig_url);
-    } else {
-        char backend_url[256];
+    const char *url_to_open = orig_url;
+    char backend_url[256];
+    if (!is_404) {
         snprintf (backend_url, sizeof(backend_url), "http://%s:%d/ham/HamClock%s",
                   backend_host, backend_port, hc_page);
-        openURL (backend_url);
+        url_to_open = backend_url;
     }
+
+    showQRCodeModal (url_to_open, title ? title : "Movie", "Scan with phone or open below", "Open Movie");
 }
 
 /* retrieve and plot latest and predicted DRAP indices, return whether io ok


### PR DESCRIPTION
### Summary of Changes

- **QR Code Modal for Movies**:
  - Replaced the direct openURL() browser invocation in openMovieURL() (ESPHamClock/wifi.cpp) with showQRCodeModal().
  - Added an optional 	itle parameter to openMovieURL() in ESPHamClock/HamClock.h.
  - Passed descriptive titles for SDO (e.g., "SDO 193 Movie") from ESPHamClock/sdo.cpp and Moon ("Moon Movie") from ESPHamClock/moonpane.cpp.

- **Framebuffer (_USE_FB0) Enhancements**:
  - In ESPHamClock/qrmodal.cpp, detect when running on fb0 without an external desktop browser. When on standalone fb0 without Live Web:
    - Omit the "Open" button and display a single centered "Close" button.
    - Change the subtitle to "Scan with phone or tablet".
    - Retain both "Open" and "Close" buttons when accessed remotely via Live Web (isLiveWebTouch()).
  - In ESPHamClock/sdo.cpp, removed the #if defined(_USE_FB0) guard around the "Show movie" menu option so fb0 users can view and scan the QR code.

### Verification
- Built and verified clean compilation and link for hamclock-800x480 (X11).
- Built and verified clean compilation and link for hamclock-fb0-800x480 (Framebuffer).
