### PR TITLE
Support QR code modal for RSS headlines and direct IP QR code in Android setup

### DIFF
--- a/ESPHamClock/rss.cpp
+++ b/ESPHamClock/rss.cpp
@@ -267,5 +267,5 @@ void scheduleRSSNow()
 void checkRSSTouch(void)
 {
     if (rss_tapurl)
-        openURL (rss_tapurl);
+        showQRCodeModal (rss_tapurl, "RSS News Story", "Scan with phone or open below", "Open Article");
 }

--- a/android/app/src/main/cpp/hamclock_jni.cpp
+++ b/android/app/src/main/cpp/hamclock_jni.cpp
@@ -13,6 +13,7 @@
 #include <android/log.h>
 
 #include "HamClock.h"
+#include "qrcodegen.h"
 
 #define TAG "HamClockNative"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
@@ -664,6 +665,54 @@ extern "C" bool android_connect_http(const char *cmd, int *read_fd) {
 
     *read_fd = pipefds[0];
     return true;
+}
+
+extern "C" JNIEXPORT jintArray JNICALL
+Java_org_openhamclock_hamclock_HamClockNative_generateQRCodePixels(
+        JNIEnv *env,
+        jclass /* clazz */,
+        jstring text,
+        jint scale,
+        jint border) {
+    if (!text) return nullptr;
+    const char *chars = env->GetStringUTFChars(text, nullptr);
+    if (!chars) return nullptr;
+
+    uint8_t qr0[qrcodegen_BUFFER_LEN_MAX];
+    uint8_t tempBuffer[qrcodegen_BUFFER_LEN_MAX];
+    bool ok = qrcodegen_encodeText(chars, tempBuffer, qr0,
+                                   qrcodegen_Ecc_LOW,
+                                   qrcodegen_VERSION_MIN, 10,
+                                   qrcodegen_Mask_AUTO, true);
+    env->ReleaseStringUTFChars(text, chars);
+    if (!ok) return nullptr;
+
+    int qr_size = qrcodegen_getSize(qr0);
+    int total_modules = qr_size + 2 * border;
+    int img_size = total_modules * scale;
+
+    std::vector<jint> pixels(img_size * img_size, (jint)0xFFFFFFFF); // White background
+
+    for (int y = 0; y < qr_size; y++) {
+        for (int x = 0; x < qr_size; x++) {
+            if (qrcodegen_getModule(qr0, x, y)) {
+                int px0 = (x + border) * scale;
+                int py0 = (y + border) * scale;
+                for (int dy = 0; dy < scale; dy++) {
+                    for (int dx = 0; dx < scale; dx++) {
+                        pixels[(py0 + dy) * img_size + (px0 + dx)] = (jint)0xFF000000; // Black
+                    }
+                }
+            }
+        }
+    }
+
+    jintArray result = env->NewIntArray((jsize)(pixels.size() + 1));
+    if (!result) return nullptr;
+    jint header = img_size;
+    env->SetIntArrayRegion(result, 0, 1, &header);
+    env->SetIntArrayRegion(result, 1, (jsize)pixels.size(), pixels.data());
+    return result;
 }
 
 

--- a/android/app/src/main/java/org/openhamclock/hamclock/HamClockNative.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/HamClockNative.kt
@@ -120,4 +120,14 @@ object HamClockNative {
 
     external fun isDaemonRunning(): Boolean
     external fun setAllowExternalAccess(allow: Boolean)
+    @JvmStatic
+    external fun generateQRCodePixels(text: String, scale: Int = 4, border: Int = 2): IntArray?
+
+    fun generateQRCodeBitmap(text: String, scale: Int = 4, border: Int = 2): android.graphics.Bitmap? {
+        val raw = generateQRCodePixels(text, scale, border) ?: return null
+        if (raw.isEmpty()) return null
+        val size = raw[0]
+        if (size <= 0 || raw.size < 1 + size * size) return null
+        return android.graphics.Bitmap.createBitmap(raw, 1, size, size, size, android.graphics.Bitmap.Config.ARGB_8888)
+    }
 }

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -42,6 +42,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.net.wifi.WifiManager
 import android.content.ClipData
@@ -198,6 +199,8 @@ class MainActivity : AppCompatActivity() {
         val etMdnsName = dialogView.findViewById<EditText>(R.id.et_mdns_name)
         val tvLocalUrlValue = dialogView.findViewById<TextView>(R.id.tv_local_url_value)
         val btnCopyLocalUrl = dialogView.findViewById<Button>(R.id.btn_copy_local_url)
+        val ivLocalAccessQr = dialogView.findViewById<ImageView>(R.id.iv_local_access_qr)
+        val tvQrCodeLabel = dialogView.findViewById<TextView>(R.id.tv_qr_code_label)
 
         etBackendHost.setText(currentHost)
         etBackendHost.setSelection(etBackendHost.text.length)
@@ -205,6 +208,16 @@ class MainActivity : AppCompatActivity() {
 
         cbAllowExternal.isChecked = currentAllowExternal
         etMdnsName.setText(currentMdnsName)
+
+        fun getQrTargetUrl(): String {
+            val ip = getDeviceIpAddress()
+            return if (!ip.isNullOrEmpty()) {
+                "http://$ip:$RW_PORT/live.html"
+            } else {
+                val host = etMdnsName.text.toString().trim().ifEmpty { (registeredMdnsName ?: "hamclock") }
+                "http://$host.local:$RW_PORT/live.html"
+            }
+        }
 
         fun formatMdnsUrl(name: String): String {
             val trimmed = name.trim()
@@ -217,6 +230,12 @@ class MainActivity : AppCompatActivity() {
         fun updateLocalAccessVisibility(isChecked: Boolean) {
             llLocalAccessDetails.visibility = if (isChecked) View.VISIBLE else View.GONE
             tvLocalUrlValue.text = formatMdnsUrl(etMdnsName.text.toString())
+            if (isChecked) {
+                val qrUrl = getQrTargetUrl()
+                val qrBmp = HamClockNative.generateQRCodeBitmap(qrUrl, scale = 5, border = 2)
+                ivLocalAccessQr.setImageBitmap(qrBmp)
+                tvQrCodeLabel.text = getString(R.string.scan_qr_to_open_ip, qrUrl)
+            }
         }
 
         updateLocalAccessVisibility(currentAllowExternal)
@@ -228,14 +247,21 @@ class MainActivity : AppCompatActivity() {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 tvLocalUrlValue.text = formatMdnsUrl(s?.toString() ?: "")
+                if (cbAllowExternal.isChecked) {
+                    val qrUrl = getQrTargetUrl()
+                    val qrBmp = HamClockNative.generateQRCodeBitmap(qrUrl, scale = 5, border = 2)
+                    ivLocalAccessQr.setImageBitmap(qrBmp)
+                    tvQrCodeLabel.text = getString(R.string.scan_qr_to_open_ip, qrUrl)
+                }
             }
             override fun afterTextChanged(s: Editable?) {}
         })
 
         btnCopyLocalUrl.setOnClickListener {
-            val url = tvLocalUrlValue.text.toString()
+            val ip = getDeviceIpAddress()
+            val copyUrl = if (!ip.isNullOrEmpty()) "http://$ip:$RW_PORT/live.html" else tvLocalUrlValue.text.toString()
             val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
-            val clip = ClipData.newPlainText("HamClock URL", url)
+            val clip = ClipData.newPlainText("HamClock URL", copyUrl)
             clipboard?.setPrimaryClip(clip)
             Toast.makeText(this, getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show()
         }
@@ -354,11 +380,53 @@ class MainActivity : AppCompatActivity() {
             btn.setPadding(32, 16, 32, 16)
         }
 
-        // Direct D-pad Down from Copy URL button to Save button
-        btnCopyLocalUrl.setOnKeyListener { _, keyCode, keyEvent ->
-            if (keyEvent.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
-                btnSave?.requestFocus()
+        val flQrCodeFrame = dialogView.findViewById<View>(R.id.fl_qr_code_frame)
+
+        // D-pad Right from mDNS name or Copy URL to QR code frame
+        etMdnsName.setOnKeyListener { _, keyCode, keyEvent ->
+            if (keyEvent.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+                flQrCodeFrame?.requestFocus()
                 true
+            } else {
+                false
+            }
+        }
+
+        btnCopyLocalUrl.setOnKeyListener { _, keyCode, keyEvent ->
+            if (keyEvent.action == KeyEvent.ACTION_DOWN) {
+                when (keyCode) {
+                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                        flQrCodeFrame?.requestFocus()
+                        true
+                    }
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        btnSave?.requestFocus()
+                        true
+                    }
+                    else -> false
+                }
+            } else {
+                false
+            }
+        }
+
+        flQrCodeFrame?.setOnKeyListener { _, keyCode, keyEvent ->
+            if (keyEvent.action == KeyEvent.ACTION_DOWN) {
+                when (keyCode) {
+                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                        btnCopyLocalUrl.requestFocus()
+                        true
+                    }
+                    KeyEvent.KEYCODE_DPAD_UP -> {
+                        cbAllowExternal.requestFocus()
+                        true
+                    }
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        btnSave?.requestFocus()
+                        true
+                    }
+                    else -> false
+                }
             } else {
                 false
             }
@@ -399,6 +467,11 @@ class MainActivity : AppCompatActivity() {
             WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
             WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
         )
+
+        val displayWidth = resources.displayMetrics.widthPixels
+        val targetWidth = (displayWidth * 0.75).toInt().coerceIn(600, 850)
+        dialog.window?.setLayout(targetWidth, WindowManager.LayoutParams.WRAP_CONTENT)
+
         dialogView.post {
             cbAllowExternal.requestFocus()
         }

--- a/android/app/src/main/res/layout/dialog_backend_settings.xml
+++ b/android/app/src/main/res/layout/dialog_backend_settings.xml
@@ -153,68 +153,116 @@
         android:id="@+id/ll_local_access_details"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
         android:focusable="false"
         android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
-        android:padding="8dp"
+        android:padding="10dp"
         android:background="#15FFFFFF"
         android:visibility="gone">
 
-        <TextView
-            android:layout_width="match_parent"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/mdns_name_label"
-            android:textColor="@color/hamclock_text"
-            android:textSize="12sp"
-            android:layout_marginBottom="4dp" />
-
-        <EditText
-            android:id="@+id/et_mdns_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/mdns_name_hint"
-            android:importantForAutofill="no"
-            android:inputType="textNoSuggestions"
-            android:imeOptions="flagNoExtractUi|actionDone"
-            android:singleLine="true"
-            android:textSize="13sp"
-            android:textColor="@color/hamclock_text"
-            android:textColorHint="#888888"
-            android:focusable="true"
-            android:padding="8dp"
-            android:background="@drawable/item_focus_highlight" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/local_url_label"
-            android:textColor="@color/hamclock_text"
-            android:textSize="12sp"
-            android:layout_marginTop="8dp" />
-
-        <TextView
-            android:id="@+id/tv_local_url_value"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="http://hamclock.local:8081/live.html"
-            android:textColor="#80D8FF"
+            android:layout_weight="1"
+            android:orientation="vertical"
             android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:textSize="13sp"
-            android:layout_marginTop="2dp"
-            android:layout_marginBottom="8dp" />
+            android:layout_marginEnd="12dp">
 
-        <Button
-            android:id="@+id/btn_copy_local_url"
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/mdns_name_label"
+                android:textColor="@color/hamclock_text"
+                android:textSize="12sp"
+                android:layout_marginBottom="4dp" />
+
+            <EditText
+                android:id="@+id/et_mdns_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/mdns_name_hint"
+                android:importantForAutofill="no"
+                android:inputType="textNoSuggestions"
+                android:imeOptions="flagNoExtractUi|actionDone"
+                android:singleLine="true"
+                android:textSize="13sp"
+                android:textColor="@color/hamclock_text"
+                android:textColorHint="#888888"
+                android:focusable="true"
+                android:padding="8dp"
+                android:background="@drawable/item_focus_highlight" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/local_url_label"
+                android:textColor="@color/hamclock_text"
+                android:textSize="12sp"
+                android:layout_marginTop="8dp" />
+
+            <TextView
+                android:id="@+id/tv_local_url_value"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="http://hamclock.local:8081/live.html"
+                android:textColor="#80D8FF"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:textSize="13sp"
+                android:layout_marginTop="2dp"
+                android:layout_marginBottom="8dp" />
+
+            <Button
+                android:id="@+id/btn_copy_local_url"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/copy_url"
+                android:textColor="@color/hamclock_text"
+                android:textSize="12sp"
+                android:background="@drawable/btn_neutral_selector"
+                android:focusable="true" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/ll_qr_code_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/copy_url"
-            android:textColor="@color/hamclock_text"
-            android:textSize="12sp"
-            android:background="@drawable/btn_neutral_selector"
-            android:focusable="true" />
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:focusable="false">
+
+            <TextView
+                android:id="@+id/tv_qr_code_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/scan_qr_to_open"
+                android:textColor="@color/hamclock_text"
+                android:textSize="11sp"
+                android:gravity="center_horizontal"
+                android:layout_marginBottom="6dp" />
+
+            <FrameLayout
+                android:id="@+id/fl_qr_code_frame"
+                android:layout_width="140dp"
+                android:layout_height="140dp"
+                android:background="@drawable/item_focus_highlight"
+                android:focusable="true"
+                android:clickable="true"
+                android:padding="4dp">
+
+                <ImageView
+                    android:id="@+id/iv_local_access_qr"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/scan_qr_to_open"
+                    android:background="#FFFFFF"
+                    android:padding="4dp"
+                    android:scaleType="fitCenter" />
+            </FrameLayout>
+        </LinearLayout>
     </LinearLayout>
 
     <View

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="local_url_label">Access from browser on your local network:</string>
     <string name="copy_url">Copy URL</string>
     <string name="copied_to_clipboard">Copied URL to clipboard</string>
+    <string name="scan_qr_to_open">Scan with phone or tablet to open:</string>
+    <string name="scan_qr_to_open_ip">Scan with phone/tablet to open:\n%1$s</string>
     <string name="server_ports_label">Server Ports:</string>
     <string name="server_ports_format">Live Web (R/W): %1$d   •   Live Web (R/O): %2$d\nRESTful API: %3$s</string>
     <string name="rest_port_label">RESTful API Port:</string>


### PR DESCRIPTION
## Summary
- **RSS Headlines:** Updated `rss.cpp` to display the standard QR code modal dialog (`showQRCodeModal`) when tapping a scrolling headline, enabling users to scan news stories on mobile or open them in a browser.
- **Android Local Access:**
  - Integrated native `qrcodegen` JNI bridge to dynamically render QR codes on Android.
  - Added a direct device IP QR code (`http://<ip>:8081/live.html`) in the Backend Settings dialog when *"Allow local network access"* is enabled.
  - Implemented a compact 2-column side-by-side layout in `dialog_backend_settings.xml` so the QR code is immediately visible on tablets and 16:9 Fire TV screens without vertical scrolling.
  - Added smooth D-pad navigation between mDNS input, Copy URL button, QR code, and dialog action buttons.
