### PR TITLE
Fix workflow_dispatch inputs evaluation and set push_amazon_appstore default to true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ on:
         options:
           - 'true'
           - 'false'
-        default: 'false'
+        default: 'true'
 
 jobs:
   release:
@@ -147,7 +147,7 @@ jobs:
 
       # Prepare release notes for Google Play Store upload
       - name: Prepare Play Store Release Notes
-        if: ${{ github.event_name == 'push' || inputs.push_play_store == true || inputs.push_play_store == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.push_play_store == 'true' || github.event.inputs.push_play_store == true || inputs.push_play_store == 'true' || inputs.push_play_store == true }}
         run: |
           mkdir -p dist/whatsnew
           rm -f dist/whatsnew/*
@@ -165,7 +165,7 @@ jobs:
 
       # Upload the signed .aab to Google Play console (Alpha track)
       - name: Upload to Google Play Alpha Track
-        if: ${{ github.event_name == 'push' || inputs.push_play_store == true || inputs.push_play_store == 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.push_play_store == 'true' || github.event.inputs.push_play_store == true || inputs.push_play_store == 'true' || inputs.push_play_store == true }}
         uses: r0adkll/upload-google-play@v1
         env:
           NODE_OPTIONS: --no-deprecation
@@ -181,7 +181,7 @@ jobs:
 
       # Upload the signed .apk to Amazon Appstore
       - name: Upload to Amazon Appstore
-        if: ${{ inputs.push_amazon_appstore == true || inputs.push_amazon_appstore == 'true' }}
+        if: ${{ github.event.inputs.push_amazon_appstore == 'true' || github.event.inputs.push_amazon_appstore == true || inputs.push_amazon_appstore == 'true' || inputs.push_amazon_appstore == true }}
         uses: galonga/upload-amazon-appstore@v1.0.2
         with:
           clientId: ${{ secrets.AMAZON_APPSTORE_CLIENT_ID }}
@@ -192,7 +192,7 @@ jobs:
       - name: Create Release and Upload Asset
         env:
           GH_TOKEN: ${{ github.token }}
-          PUBLISH_RELEASE: ${{ inputs.publish_release }}
+          PUBLISH_RELEASE: ${{ github.event.inputs.publish_release != '' && github.event.inputs.publish_release || inputs.publish_release }}
         run: |
           TAG="${{ github.event.inputs.tag_name }}"
           HC_TAG=${TAG%.*}
@@ -237,7 +237,7 @@ jobs:
     name: Build and Push Docker Image
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ needs.release.result == 'success' && (github.event_name == 'push' || inputs.build_docker == true || inputs.build_docker == 'true') }}
+    if: ${{ needs.release.result == 'success' && (github.event_name == 'push' || github.event.inputs.build_docker == 'true' || github.event.inputs.build_docker == true || inputs.build_docker == 'true' || inputs.build_docker == true) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,8 +42,8 @@ gh workflow run release.yml -f tag_name=v4.32.0 -f build_docker=false
 # Optional: skip uploading to Google Play Store:
 gh workflow run release.yml -f tag_name=v4.32.0 -f push_play_store=false
 
-# Optional: upload to Amazon Appstore (defaults to false):
-gh workflow run release.yml -f tag_name=v4.32.0 -f push_amazon_appstore=true
+# Optional: skip uploading to Amazon Appstore:
+gh workflow run release.yml -f tag_name=v4.32.0 -f push_amazon_appstore=false
 
 # Optional: draft release without Docker build or app store uploads:
 gh workflow run release.yml -f tag_name=v4.32.0 -f publish_release=false -f build_docker=false -f push_play_store=false -f push_amazon_appstore=false
@@ -70,7 +70,7 @@ gh workflow run
 | `publish_release` | choice (`true`, `false`) | `true` | When `true`, publishes the release immediately. Set to `false` to create as a draft. |
 | `build_docker` | choice (`true`, `false`) | `true` | When `true`, builds and pushes the multi-platform Docker image. |
 | `push_play_store` | choice (`true`, `false`) | `true` | When `true`, uploads the Android AAB to Google Play (Alpha track). |
-| `push_amazon_appstore` | choice (`true`, `false`) | `false` | When `true`, uploads the Android APK to the Amazon Appstore. |
+| `push_amazon_appstore` | choice (`true`, `false`) | `true` | When `true`, uploads the Android APK to the Amazon Appstore. |
 
 ### Monitoring the Workflow
 


### PR DESCRIPTION
### Summary of Changes
1. **Support CLI & Event Inputs Across All Flags**: Updated conditional expressions for `push_play_store`, `push_amazon_appstore`, `publish_release`, and `build_docker` to evaluate `github.event.inputs` alongside `inputs`. This ensures parameters passed via `gh workflow run -f flag=value` or the GitHub UI override the static defaults.
2. **Default Amazon Appstore to `true`**: Changed `push_amazon_appstore` default from `false` to `true` in [.github/workflows/release.yml](file:///.github/workflows/release.yml).
3. **Updated Documentation**: Updated [RELEASE.md](file:///RELEASE.md) to reflect the new default and examples for disabling Amazon Appstore upload when desired.