### PR TITLE
Only use GeoIP on first setup when GPS is unavailable on Android

### DIFF
--- a/android/app/src/main/cpp/hamclock_jni.cpp
+++ b/android/app/src/main/cpp/hamclock_jni.cpp
@@ -334,11 +334,19 @@ static void *daemon_worker(void *arg) {
     argv.push_back(const_cast<char *>(restVal.c_str()));
     argv.push_back(const_cast<char *>(throtFlag.c_str()));
     argv.push_back(const_cast<char *>(throtVal.c_str()));
+    // Check if initial setup has been performed (callsign configured)
+    char callsign[NV_CALLSIGN_LEN] = {0};
+    bool isFirstSetup = !NVReadString(NV_CALLSIGN, callsign) || callsign[0] == '\0';
+
     if (!forceSetup && !countdownSetup) {
         argv.push_back(const_cast<char *>(skipFlag.c_str()));
         if (!hasLoc) {
-            argv.push_back(const_cast<char *>(geoFlag.c_str()));
-            LOGI("Host GPS location not available: falling back to GeoIP (-g)");
+            if (isFirstSetup) {
+                argv.push_back(const_cast<char *>(geoFlag.c_str()));
+                LOGI("Host GPS location not available on first setup: initializing location with GeoIP (-g)");
+            } else {
+                LOGI("Host GPS location not available (already configured): preserving saved DE location");
+            }
         }
     }
     if (!bVal.empty()) {


### PR DESCRIPTION
### Summary

- **Context**: On Android devices without GPS (e.g. Fire TV, Android TV, or tablets without a GPS fix), HamClock previously passed `-g` (GeoIP fallback) on every boot. This caused any manual location/grid/tz set by the user in Setup or via the web interface to be overwritten by GeoIP on every restart if GeoIP did not match the user's actual location.
- **Change**: When host GPS is unavailable, check if the app is at initial setup (unconfigured callsign in NVRAM). Only pass `-g` on first setup to seed the initial coordinates. On subsequent restarts/reboots, preserve the user's manual/saved DE location in NVRAM without overwriting it with GeoIP.
- **GPS Devices**: Devices with active GPS coordinates continue to update the location on every start as before.