### PR TITLE
Add virtual remote pointer for Fire TV D-Pad navigation and clicking

### DIFF
--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -96,6 +96,23 @@ char live_html[] =  R"_raw_html_(
             border-bottom: 1px solid #888;
         }
 
+        #virtual-cursor {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 28px;
+            height: 28px;
+            pointer-events: none;
+            z-index: 9999;
+            transform: translate3d(-100px, -100px, 0);
+            transition: opacity 0.25s ease, transform 0.05s ease-out;
+            filter: drop-shadow(0 2px 5px rgba(0,0,0,0.85));
+        }
+        #virtual-cursor.clicking {
+            transform: scale(0.85);
+        }
+
     </style>
 
     <script>
@@ -125,6 +142,98 @@ char live_html[] =  R"_raw_html_(
         var want_fs, tried_fs;          // whether user wants full screen and has succeeded once
         var wsclose_reload = 1;         // whether to reload if lose ws connection
         var cvs, ctx;                   // handy
+
+        // virtual cursor state for remote control / D-pad
+        var vcursor_el = null;
+        var vcursor_x = APP_W / 2;      // app coords x (init 400)
+        var vcursor_y = 240;            // app coords y (init 240)
+        var vcursor_visible = false;
+        var vcursor_hide_timer = null;
+        var last_arrow_ms = 0;
+        var arrow_repeat_count = 0;
+        const VCURSOR_HIDE_MS = 12000;  // auto-hide after 12s of inactivity
+
+        function updateVirtualCursorDom() {
+            if (!vcursor_el || !cvs || !app_scale) return;
+            const rect = cvs.getBoundingClientRect();
+            const domX = rect.left + vcursor_x * app_scale;
+            const domY = rect.top + vcursor_y * app_scale;
+            vcursor_el.style.transform = 'translate3d(' + Math.round(domX) + 'px, ' + Math.round(domY) + 'px, 0px)';
+        }
+
+        function showVirtualCursor() {
+            if (!vcursor_el) return;
+            vcursor_el.style.display = 'block';
+            vcursor_visible = true;
+            updateVirtualCursorDom();
+            resetVirtualCursorTimer();
+        }
+
+        function hideVirtualCursor() {
+            if (!vcursor_el) return;
+            vcursor_el.style.display = 'none';
+            vcursor_visible = false;
+            if (vcursor_hide_timer) {
+                clearTimeout(vcursor_hide_timer);
+                vcursor_hide_timer = null;
+            }
+        }
+
+        function resetVirtualCursorTimer() {
+            if (vcursor_hide_timer)
+                clearTimeout(vcursor_hide_timer);
+            vcursor_hide_timer = setTimeout(hideVirtualCursor, VCURSOR_HIDE_MS);
+        }
+
+        function handleVirtualCursorMove(direction) {
+            const now = Date.now();
+            let step = 12;
+            if (now - last_arrow_ms < 180) {
+                arrow_repeat_count++;
+                if (arrow_repeat_count > 12) step = 28;
+                else if (arrow_repeat_count > 5) step = 18;
+            } else {
+                arrow_repeat_count = 0;
+            }
+            last_arrow_ms = now;
+
+            if (!vcursor_visible) {
+                showVirtualCursor();
+            }
+
+            if (direction === 'ArrowLeft') vcursor_x -= step;
+            else if (direction === 'ArrowRight') vcursor_x += step;
+            else if (direction === 'ArrowUp') vcursor_y -= step;
+            else if (direction === 'ArrowDown') vcursor_y += step;
+
+            // clamp to app bounds (0..799, 0..479)
+            vcursor_x = Math.max(0, Math.min(APP_W - 1, vcursor_x));
+            vcursor_y = Math.max(0, Math.min(479, vcursor_y));
+
+            updateVirtualCursorDom();
+            resetVirtualCursorTimer();
+
+            // update HamClock hover position
+            sendWSMsg('set_mouse?x=' + vcursor_x + '&y=' + vcursor_y);
+        }
+
+        function handleVirtualCursorClick() {
+            if (!vcursor_visible) {
+                showVirtualCursor();
+            }
+
+            // brief click feedback animation
+            if (vcursor_el) {
+                vcursor_el.classList.add('clicking');
+                setTimeout(function() {
+                    if (vcursor_el) vcursor_el.classList.remove('clicking');
+                }, 120);
+            }
+
+            // send touch to HamClock
+            sendWSMsg('set_touch?x=' + vcursor_x + '&y=' + vcursor_y + '&button=0');
+            resetVirtualCursorTimer();
+        }
 
         // define functions, onLoad follows near the bottom
 
@@ -182,6 +291,7 @@ char live_html[] =  R"_raw_html_(
             cvs.style.left = "50%";
             cvs.style.margin = (-hc_h/2) + "px" + " 0 0 " + (-hc_w/2) + "px"; // trbl
             app_scale = hc_w/APP_W;
+            updateVirtualCursorDom();
 
             if (drawing_verbose)
                 console.log ("canvas is " + hc_w + " x " + hc_h + " app_scale " + app_scale);
@@ -302,6 +412,20 @@ char live_html[] =  R"_raw_html_(
 
         // send the given key and optionl control and shift modifier codes to the hamclock
         function sendKey (k, c, s) {
+
+            // handle D-pad arrow keys for virtual remote cursor
+            if (k === 'ArrowUp' || k === 'ArrowDown' || k === 'ArrowLeft' || k === 'ArrowRight') {
+                handleVirtualCursorMove (k);
+                return;
+            }
+
+            // handle Enter / Select for virtual remote cursor
+            if (k === 'Enter') {
+                if (vcursor_visible || (window.AndroidApp && window.AndroidApp.setEmbedVisible)) {
+                    handleVirtualCursorClick();
+                    return;
+                }
+            }
 
             // a real space would send 'char= ' which doesn't parse so we invent Space name
             if (k === ' ')
@@ -649,6 +773,11 @@ char live_html[] =  R"_raw_html_(
                 cancelLongPress();
                 longpress_fired = false;
 
+                // hide virtual cursor on real touch/pointer tap
+                if (event.pointerType !== 'mouse' || event.isPrimary) {
+                    hideVirtualCursor();
+                }
+
                 pointermove_ms = Date.now();
                 pointerdown_x = m.x;
                 pointerdown_y = m.y;
@@ -772,6 +901,9 @@ char live_html[] =  R"_raw_html_(
             });
 
 
+            // grab virtual cursor element
+            vcursor_el = document.getElementById('virtual-cursor');
+
             // all set. start things off with the full image, repeats from then on with updates forever.
             getFullImage();
 
@@ -785,6 +917,14 @@ char live_html[] =  R"_raw_html_(
 
     <!-- page is a single canvas, size will be set based on hamclock build size -->
     <canvas id='hamclock-cvs'></canvas>
+
+    <!-- on-screen virtual pointer for remote control navigation -->
+    <div id='virtual-cursor'>
+        <svg width="28" height="28" viewBox="0 0 28 28" fill="none" style="position:absolute;top:0;left:0;" xmlns="http://www.w3.org/2000/svg">
+            <polygon points="1,1 1,23 6.8,17.2 12,27 15.5,25 10.3,15.5 18,15.5" fill="#000000"/>
+            <polygon points="2,3 2,20.5 6.5,16 11.2,24.8 13.5,23.5 8.8,14.8 15.5,14.8" fill="#FFFFFF"/>
+        </svg>
+    </div>
 
     <!-- in-page overlay for embedded links (e.g. ADS-B badge), toggled by showEmbed()/hideEmbed() -->
     <div id='embed-overlay'>

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -1071,24 +1071,16 @@ class MainActivity : AppCompatActivity() {
                 return true
             }
 
-            // If settings button is currently focused on the main screen
+            // If settings button is explicitly focused
             if (btnSettings.isFocused) {
                 when (event.keyCode) {
                     KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
                         btnSettings.performClick()
                         return true
                     }
-                    KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_BACK -> {
+                    KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.KEYCODE_BACK -> {
                         btnSettings.clearFocus()
                         webView.requestFocus()
-                        return true
-                    }
-                }
-            } else {
-                // If settings button is NOT focused, navigate to it on Down or Right
-                when (event.keyCode) {
-                    KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                        btnSettings.requestFocus()
                         return true
                     }
                 }


### PR DESCRIPTION
## Summary
This PR adds an on-screen virtual pointer (mouse cursor) controlled directly by the Fire TV remote's D-Pad and Select button to satisfy Amazon Appstore Fire TV certification requirements.

## Key Changes
- **LiveWeb Frontend (`liveweb-html.cpp`)**:
  - Added an SVG-rendered high-contrast virtual cursor overlay (`#virtual-cursor`) with hardware-accelerated `translate3d` positioning.
  - Directional keys (`ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`) move the cursor with dynamic acceleration.
  - Select/Enter (`Enter`) triggers simulated touch taps (`set_touch`) at the cursor coordinates.
  - Auto-hides after 12 seconds of inactivity and instantly hides on physical touchscreen taps.
- **Android (`MainActivity.kt`)**:
  - Removed focus hijacking on `btnSettings` for D-Pad Down/Right so D-Pad events route directly into WebView `sendKey()`.
  - Backend settings dialog remains accessible via Menu button, Play/Pause, long-pressing Select, or clicking the gear icon.

## Testing
- Verified via live deployment and remote control key simulation on a physical Amazon Fire TV Stick.