### PR TITLE
Enhance Android Settings: Antenna QR switcher, background execution, and layout declutter

### DIFF
--- a/.github/scripts/upload_amazon_appstore.py
+++ b/.github/scripts/upload_amazon_appstore.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Upload an APK and update release notes (recentChanges) on the Amazon Appstore
+using the Amazon App Submission REST API.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+LWA_TOKEN_URL = "https://api.amazon.com/auth/o2/token"
+API_BASE_URL = "https://developer.amazon.com/api/appstore/v1/applications"
+
+
+def get_lwa_token(client_id: str, client_secret: str) -> str:
+    """Request Login with Amazon (LWA) OAuth access token."""
+    print("Requesting Login with Amazon (LWA) access token...")
+    payload = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": "appstore::apps:readwrite",
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        LWA_TOKEN_URL,
+        data=payload,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data["access_token"]
+    except urllib.error.HTTPError as e:
+        error_msg = e.read().decode("utf-8", errors="replace")
+        print(f"Error authenticating with Amazon LWA: HTTP {e.code}: {error_msg}", file=sys.stderr)
+        sys.exit(1)
+
+
+def api_request(url: str, token: str, method: str = "GET", data: bytes = None, headers: dict = None) -> tuple:
+    """Perform an authenticated request to the Amazon App Submission API."""
+    req_headers = {
+        "Authorization": f"Bearer {token}",
+    }
+    if headers:
+        req_headers.update(headers)
+
+    req = urllib.request.Request(url, data=data, headers=req_headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp_data = resp.read()
+            resp_headers = resp.headers
+            return resp.status, resp_headers, resp_data
+    except urllib.error.HTTPError as e:
+        error_msg = e.read().decode("utf-8", errors="replace")
+        print(f"API Error [{method} {url}]: HTTP {e.code}: {error_msg}", file=sys.stderr)
+        sys.exit(1)
+
+
+def create_or_get_edit(app_id: str, token: str) -> str:
+    """Create a new edit session (upcoming version) for the application."""
+    print(f"Creating edit session for App ID: {app_id}...")
+    url = f"{API_BASE_URL}/{app_id}/edits"
+    _, _, data = api_request(url, token, method="POST", headers={"Content-Type": "application/json"})
+    edit_info = json.loads(data.decode("utf-8"))
+    edit_id = edit_info.get("id")
+    print(f"Edit session created with ID: {edit_id}")
+    return edit_id
+
+
+def upload_apk(app_id: str, edit_id: str, token: str, apk_path: str):
+    """Upload or replace APK in the active edit session."""
+    print(f"Checking existing APKs in edit session {edit_id}...")
+    apks_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/apks"
+    _, _, data = api_request(apks_url, token, method="GET")
+    existing_apks = json.loads(data.decode("utf-8"))
+
+    file_size = os.path.getsize(apk_path)
+    print(f"Uploading APK ({apk_path}, {file_size} bytes)...")
+
+    with open(apk_path, "rb") as f:
+        apk_bytes = f.read()
+
+    headers = {
+        "Content-Type": "application/vnd.android.package-archive",
+    }
+
+    if existing_apks and len(existing_apks) > 0:
+        apk_id = existing_apks[0].get("id")
+        print(f"Replacing existing APK (ID: {apk_id})...")
+        upload_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/apks/{apk_id}/replace"
+        api_request(upload_url, token, method="PUT", data=apk_bytes, headers=headers)
+    else:
+        print("Uploading new APK...")
+        upload_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/apks/upload"
+        api_request(upload_url, token, method="POST", data=apk_bytes, headers=headers)
+
+    print("APK upload complete.")
+
+
+def update_release_notes(app_id: str, edit_id: str, token: str, notes_file: str):
+    """Update recentChanges (release notes) for the listing."""
+    if not notes_file or not os.path.isfile(notes_file):
+        print(f"No release notes file found at '{notes_file}', skipping release notes update.")
+        return
+
+    with open(notes_file, "r", encoding="utf-8", errors="replace") as f:
+        notes_content = f.read().strip()
+
+    if not notes_content:
+        print("Release notes file is empty, skipping release notes update.")
+        return
+
+    print(f"Updating release notes (recentChanges) from {notes_file}...")
+
+    # Get available listings
+    listings_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/listings"
+    _, _, data = api_request(listings_url, token, method="GET")
+    listings = json.loads(data.decode("utf-8"))
+
+    target_languages = []
+    if isinstance(listings, list) and listings:
+        target_languages = [l.get("language") for l in listings if "language" in l]
+    elif isinstance(listings, dict):
+        target_languages = list(listings.keys())
+
+    if not target_languages:
+        target_languages = ["en-US"]
+
+    for lang in target_languages:
+        listing_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/listings/{lang}"
+        _, headers, list_data = api_request(listing_url, token, method="GET")
+        etag = headers.get("ETag")
+        listing_json = json.loads(list_data.decode("utf-8"))
+
+        print(f"Updating recentChanges for language: {lang}")
+        listing_json["recentChanges"] = notes_content
+
+        put_headers = {
+            "Content-Type": "application/json",
+        }
+        if etag:
+            put_headers["If-Match"] = etag
+
+        payload = json.dumps(listing_json).encode("utf-8")
+        api_request(listing_url, token, method="PUT", data=payload, headers=put_headers)
+
+    print("Release notes updated successfully.")
+
+
+def commit_edit(app_id: str, edit_id: str, token: str):
+    """Commit the edit session to submit for review."""
+    print(f"Committing edit session {edit_id} for review...")
+    commit_url = f"{API_BASE_URL}/{app_id}/edits/{edit_id}/commit"
+    api_request(commit_url, token, method="POST")
+    print("Edit committed successfully! Upcoming version submitted for review.")
+
+
+def resolve_apk_path(pattern: str) -> str:
+    """Find the APK file matching the given glob pattern."""
+    matches = glob.glob(pattern)
+    if not matches:
+        raise FileNotFoundError(f"No APK file found matching pattern: {pattern}")
+    return matches[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload APK and update release notes on Amazon Appstore")
+    parser.add_argument("--client-id", required=True, help="Amazon LWA Client ID")
+    parser.add_argument("--client-secret", required=True, help="Amazon LWA Client Secret")
+    parser.add_argument("--app-id", required=True, help="Amazon Appstore App ID")
+    parser.add_argument("--apk", required=True, help="Path or glob pattern for the release APK")
+    parser.add_argument("--notes-file", default="", help="Path to release notes text file")
+
+    args = parser.parse_args()
+
+    apk_file = resolve_apk_path(args.apk)
+    print(f"Target APK: {apk_file}")
+
+    token = get_lwa_token(args.client_id, args.client_secret)
+    edit_id = create_or_get_edit(args.app_id, token)
+
+    upload_apk(args.app_id, edit_id, token, apk_file)
+
+    if args.notes_file:
+        update_release_notes(args.app_id, edit_id, token, args.notes_file)
+
+    commit_edit(args.app_id, edit_id, token)
+    print("Amazon Appstore upload and release notes update completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,9 @@ jobs:
             cp app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip ../dist/native-debug-symbols.zip
           fi
 
-      # Prepare release notes for Google Play Store upload
-      - name: Prepare Play Store Release Notes
-        if: ${{ github.event_name == 'push' || github.event.inputs.push_play_store == 'true' || github.event.inputs.push_play_store == true || inputs.push_play_store == 'true' || inputs.push_play_store == true }}
+      # Prepare release notes for app store uploads (Google Play / Amazon Appstore)
+      - name: Prepare Store Release Notes
+        if: ${{ github.event_name == 'push' || github.event.inputs.push_play_store == 'true' || github.event.inputs.push_play_store == true || inputs.push_play_store == 'true' || inputs.push_play_store == true || github.event.inputs.push_amazon_appstore == 'true' || github.event.inputs.push_amazon_appstore == true || inputs.push_amazon_appstore == 'true' || inputs.push_amazon_appstore == true }}
         run: |
           mkdir -p dist/whatsnew
           rm -f dist/whatsnew/*
@@ -179,15 +179,16 @@ jobs:
           mappingFile: dist/mapping.txt
           debugSymbols: dist/native-debug-symbols.zip
 
-      # Upload the signed .apk to Amazon Appstore
+      # Upload the signed .apk and release notes to Amazon Appstore
       - name: Upload to Amazon Appstore
         if: ${{ github.event.inputs.push_amazon_appstore == 'true' || github.event.inputs.push_amazon_appstore == true || inputs.push_amazon_appstore == 'true' || inputs.push_amazon_appstore == true }}
-        uses: galonga/upload-amazon-appstore@v1.0.2
-        with:
-          clientId: ${{ secrets.AMAZON_APPSTORE_CLIENT_ID }}
-          clientSecret: ${{ secrets.AMAZON_APPSTORE_CLIENT_SECRET }}
-          appId: ${{ secrets.AMAZON_APPSTORE_APP_ID }}
-          releaseFile: dist/org.openhamclock*.apk
+        run: |
+          python3 .github/scripts/upload_amazon_appstore.py \
+            --client-id "${{ secrets.AMAZON_APPSTORE_CLIENT_ID }}" \
+            --client-secret "${{ secrets.AMAZON_APPSTORE_CLIENT_SECRET }}" \
+            --app-id "${{ secrets.AMAZON_APPSTORE_APP_ID }}" \
+            --apk "dist/org.openhamclock*.apk" \
+            --notes-file "dist/whatsnew/whatsnew-en-US"
 
       - name: Create Release and Upload Asset
         env:

--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -96,6 +96,23 @@ char live_html[] =  R"_raw_html_(
             border-bottom: 1px solid #888;
         }
 
+        #virtual-cursor {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 28px;
+            height: 28px;
+            pointer-events: none;
+            z-index: 9999;
+            transform: translate3d(-100px, -100px, 0);
+            transition: opacity 0.25s ease, transform 0.05s ease-out;
+            filter: drop-shadow(0 2px 5px rgba(0,0,0,0.85));
+        }
+        #virtual-cursor.clicking {
+            transform: scale(0.85);
+        }
+
     </style>
 
     <script>
@@ -125,6 +142,98 @@ char live_html[] =  R"_raw_html_(
         var want_fs, tried_fs;          // whether user wants full screen and has succeeded once
         var wsclose_reload = 1;         // whether to reload if lose ws connection
         var cvs, ctx;                   // handy
+
+        // virtual cursor state for remote control / D-pad
+        var vcursor_el = null;
+        var vcursor_x = APP_W / 2;      // app coords x (init 400)
+        var vcursor_y = 240;            // app coords y (init 240)
+        var vcursor_visible = false;
+        var vcursor_hide_timer = null;
+        var last_arrow_ms = 0;
+        var arrow_repeat_count = 0;
+        const VCURSOR_HIDE_MS = 12000;  // auto-hide after 12s of inactivity
+
+        function updateVirtualCursorDom() {
+            if (!vcursor_el || !cvs || !app_scale) return;
+            const rect = cvs.getBoundingClientRect();
+            const domX = rect.left + vcursor_x * app_scale;
+            const domY = rect.top + vcursor_y * app_scale;
+            vcursor_el.style.transform = 'translate3d(' + Math.round(domX) + 'px, ' + Math.round(domY) + 'px, 0px)';
+        }
+
+        function showVirtualCursor() {
+            if (!vcursor_el) return;
+            vcursor_el.style.display = 'block';
+            vcursor_visible = true;
+            updateVirtualCursorDom();
+            resetVirtualCursorTimer();
+        }
+
+        function hideVirtualCursor() {
+            if (!vcursor_el) return;
+            vcursor_el.style.display = 'none';
+            vcursor_visible = false;
+            if (vcursor_hide_timer) {
+                clearTimeout(vcursor_hide_timer);
+                vcursor_hide_timer = null;
+            }
+        }
+
+        function resetVirtualCursorTimer() {
+            if (vcursor_hide_timer)
+                clearTimeout(vcursor_hide_timer);
+            vcursor_hide_timer = setTimeout(hideVirtualCursor, VCURSOR_HIDE_MS);
+        }
+
+        function handleVirtualCursorMove(direction) {
+            const now = Date.now();
+            let step = 12;
+            if (now - last_arrow_ms < 180) {
+                arrow_repeat_count++;
+                if (arrow_repeat_count > 12) step = 28;
+                else if (arrow_repeat_count > 5) step = 18;
+            } else {
+                arrow_repeat_count = 0;
+            }
+            last_arrow_ms = now;
+
+            if (!vcursor_visible) {
+                showVirtualCursor();
+            }
+
+            if (direction === 'ArrowLeft') vcursor_x -= step;
+            else if (direction === 'ArrowRight') vcursor_x += step;
+            else if (direction === 'ArrowUp') vcursor_y -= step;
+            else if (direction === 'ArrowDown') vcursor_y += step;
+
+            // clamp to app bounds (0..799, 0..479)
+            vcursor_x = Math.max(0, Math.min(APP_W - 1, vcursor_x));
+            vcursor_y = Math.max(0, Math.min(479, vcursor_y));
+
+            updateVirtualCursorDom();
+            resetVirtualCursorTimer();
+
+            // update HamClock hover position
+            sendWSMsg('set_mouse?x=' + vcursor_x + '&y=' + vcursor_y);
+        }
+
+        function handleVirtualCursorClick() {
+            if (!vcursor_visible) {
+                showVirtualCursor();
+            }
+
+            // brief click feedback animation
+            if (vcursor_el) {
+                vcursor_el.classList.add('clicking');
+                setTimeout(function() {
+                    if (vcursor_el) vcursor_el.classList.remove('clicking');
+                }, 120);
+            }
+
+            // send touch to HamClock
+            sendWSMsg('set_touch?x=' + vcursor_x + '&y=' + vcursor_y + '&button=0');
+            resetVirtualCursorTimer();
+        }
 
         // define functions, onLoad follows near the bottom
 
@@ -182,6 +291,7 @@ char live_html[] =  R"_raw_html_(
             cvs.style.left = "50%";
             cvs.style.margin = (-hc_h/2) + "px" + " 0 0 " + (-hc_w/2) + "px"; // trbl
             app_scale = hc_w/APP_W;
+            updateVirtualCursorDom();
 
             if (drawing_verbose)
                 console.log ("canvas is " + hc_w + " x " + hc_h + " app_scale " + app_scale);
@@ -302,6 +412,20 @@ char live_html[] =  R"_raw_html_(
 
         // send the given key and optionl control and shift modifier codes to the hamclock
         function sendKey (k, c, s) {
+
+            // handle D-pad arrow keys for virtual remote cursor
+            if (k === 'ArrowUp' || k === 'ArrowDown' || k === 'ArrowLeft' || k === 'ArrowRight') {
+                handleVirtualCursorMove (k);
+                return;
+            }
+
+            // handle Enter / Select for virtual remote cursor
+            if (k === 'Enter') {
+                if (vcursor_visible || (window.AndroidApp && window.AndroidApp.setEmbedVisible)) {
+                    handleVirtualCursorClick();
+                    return;
+                }
+            }
 
             // a real space would send 'char= ' which doesn't parse so we invent Space name
             if (k === ' ')
@@ -649,6 +773,11 @@ char live_html[] =  R"_raw_html_(
                 cancelLongPress();
                 longpress_fired = false;
 
+                // hide virtual cursor on real touch/pointer tap
+                if (event.pointerType !== 'mouse' || event.isPrimary) {
+                    hideVirtualCursor();
+                }
+
                 pointermove_ms = Date.now();
                 pointerdown_x = m.x;
                 pointerdown_y = m.y;
@@ -772,6 +901,9 @@ char live_html[] =  R"_raw_html_(
             });
 
 
+            // grab virtual cursor element
+            vcursor_el = document.getElementById('virtual-cursor');
+
             // all set. start things off with the full image, repeats from then on with updates forever.
             getFullImage();
 
@@ -785,6 +917,14 @@ char live_html[] =  R"_raw_html_(
 
     <!-- page is a single canvas, size will be set based on hamclock build size -->
     <canvas id='hamclock-cvs'></canvas>
+
+    <!-- on-screen virtual pointer for remote control navigation -->
+    <div id='virtual-cursor'>
+        <svg width="28" height="28" viewBox="0 0 28 28" fill="none" style="position:absolute;top:0;left:0;" xmlns="http://www.w3.org/2000/svg">
+            <polygon points="1,1 1,23 6.8,17.2 12,27 15.5,25 10.3,15.5 18,15.5" fill="#000000"/>
+            <polygon points="2,3 2,20.5 6.5,16 11.2,24.8 13.5,23.5 8.8,14.8 15.5,14.8" fill="#FFFFFF"/>
+        </svg>
+    </div>
 
     <!-- in-page overlay for embedded links (e.g. ADS-B badge), toggled by showEmbed()/hideEmbed() -->
     <div id='embed-overlay'>

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : AppCompatActivity() {
     private val PREF_START_ON_BOOT = "start_on_boot"
     private val PREF_ALLOW_EXTERNAL = "allow_external_access"
     private val PREF_MDNS_NAME = "mdns_name"
+    private val PREF_RUN_IN_BACKGROUND = "run_in_background"
 
     private val REST_PORT = 8080
     private val RW_PORT = 8081
@@ -73,6 +74,7 @@ class MainActivity : AppCompatActivity() {
 
     private var actualRestPort = 8080
     private var restPortConflict = false
+    private var isExplicitExit = false
 
     private var wifiLock: WifiManager.WifiLock? = null
     private var nsdManager: NsdManager? = null
@@ -126,6 +128,7 @@ class MainActivity : AppCompatActivity() {
             override fun onExitRequested() {
                 mainHandler.post {
                     Log.i(TAG, "Exit requested by native HamClock engine")
+                    isExplicitExit = true
                     finishAndRemoveTask()
                 }
             }
@@ -237,11 +240,21 @@ class MainActivity : AppCompatActivity() {
 
         val cbAllowExternal = dialogView.findViewById<CheckBox>(R.id.cb_allow_external)
         val llLocalAccessDetails = dialogView.findViewById<LinearLayout>(R.id.ll_local_access_details)
+        val btnTabLive = dialogView.findViewById<Button>(R.id.btn_tab_live)
+        val btnTabAntennas = dialogView.findViewById<Button>(R.id.btn_tab_antennas)
+        val tvLocalUrlLabel = dialogView.findViewById<TextView>(R.id.tv_local_url_label)
         val etMdnsName = dialogView.findViewById<EditText>(R.id.et_mdns_name)
         val tvLocalUrlValue = dialogView.findViewById<TextView>(R.id.tv_local_url_value)
         val btnCopyLocalUrl = dialogView.findViewById<Button>(R.id.btn_copy_local_url)
         val ivLocalAccessQr = dialogView.findViewById<ImageView>(R.id.iv_local_access_qr)
         val tvQrCodeLabel = dialogView.findViewById<TextView>(R.id.tv_qr_code_label)
+        val tvQrUrlValue = dialogView.findViewById<TextView>(R.id.tv_qr_url_value)
+        val cbRunInBackground = dialogView.findViewById<CheckBox>(R.id.cb_run_in_background)
+
+        val currentRunInBackground = prefs.getBoolean(PREF_RUN_IN_BACKGROUND, false)
+        cbRunInBackground.isChecked = currentRunInBackground
+
+        var currentTab = 0 // 0 = Live Clock, 1 = Antennas
 
         if (isFirstRunTv) {
             llTvSetupGuide.visibility = View.VISIBLE
@@ -253,33 +266,65 @@ class MainActivity : AppCompatActivity() {
 
         etMdnsName.setText(currentMdnsName)
 
-        fun getQrTargetUrl(): String {
+        fun getEndpointTargetUrl(tab: Int): String {
             val ip = getDeviceIpAddress()
-            return if (!ip.isNullOrEmpty()) {
-                "http://$ip:$RW_PORT/live.html"
+            val host = if (!ip.isNullOrEmpty()) ip else {
+                val entered = etMdnsName.text.toString().trim()
+                if (entered.isNotEmpty()) "$entered.local" else (registeredMdnsName ?: "hamclock") + ".local"
+            }
+            return if (tab == 0) {
+                "http://$host:$RW_PORT/live.html"
             } else {
-                val host = etMdnsName.text.toString().trim().ifEmpty { (registeredMdnsName ?: "hamclock") }
-                "http://$host.local:$RW_PORT/live.html"
+                val port = if (actualRestPort > 0) actualRestPort else REST_PORT
+                "http://$host:$port/antennas.html"
             }
         }
 
-        fun formatMdnsUrl(name: String): String {
+        fun formatMdnsUrl(name: String, tab: Int): String {
             val trimmed = name.trim()
-            val host = if (trimmed.isNotEmpty()) trimmed else (registeredMdnsName ?: "hamclock")
-            val ip = getDeviceIpAddress()
-            val ipText = if (!ip.isNullOrEmpty()) "\nIP: http://$ip:$RW_PORT/live.html" else ""
-            return "http://$host.local:$RW_PORT/live.html$ipText"
+            val host = if (trimmed.isNotEmpty()) "$trimmed.local" else (registeredMdnsName ?: "hamclock") + ".local"
+            return if (tab == 0) {
+                "http://$host:$RW_PORT/live.html"
+            } else {
+                if (actualRestPort <= 0) {
+                    getString(R.string.rest_port_disabled)
+                } else {
+                    "http://$host:$actualRestPort/antennas.html"
+                }
+            }
         }
 
         fun updateLocalAccessVisibility(isChecked: Boolean) {
             llLocalAccessDetails.visibility = if (isChecked) View.VISIBLE else View.GONE
-            tvLocalUrlValue.text = formatMdnsUrl(etMdnsName.text.toString())
+
+            if (currentTab == 0) {
+                btnTabLive.setBackgroundResource(R.drawable.btn_setup_selector)
+                btnTabAntennas.setBackgroundResource(R.drawable.btn_neutral_selector)
+                tvLocalUrlLabel.text = getString(R.string.local_url_label)
+            } else {
+                btnTabLive.setBackgroundResource(R.drawable.btn_neutral_selector)
+                btnTabAntennas.setBackgroundResource(R.drawable.btn_setup_selector)
+                tvLocalUrlLabel.text = getString(R.string.antenna_url_label)
+            }
+
+            tvLocalUrlValue.text = formatMdnsUrl(etMdnsName.text.toString(), currentTab)
             if (isChecked) {
-                val qrUrl = getQrTargetUrl()
+                val qrUrl = getEndpointTargetUrl(currentTab)
                 val qrBmp = HamClockNative.generateQRCodeBitmap(qrUrl, scale = 5, border = 2)
                 ivLocalAccessQr.setImageBitmap(qrBmp)
-                tvQrCodeLabel.text = getString(R.string.scan_qr_to_open_ip, qrUrl)
+                tvQrCodeLabel.text = getString(R.string.scan_qr_to_open)
+                tvQrUrlValue.text = qrUrl
             }
+        }
+
+        btnTabLive.setOnClickListener {
+            currentTab = 0
+            updateLocalAccessVisibility(cbAllowExternal.isChecked)
+        }
+
+        btnTabAntennas.setOnClickListener {
+            currentTab = 1
+            updateLocalAccessVisibility(cbAllowExternal.isChecked)
         }
 
         // For first run TV guidance, auto-check local network access so QR and web access are immediately live
@@ -307,12 +352,13 @@ class MainActivity : AppCompatActivity() {
         etMdnsName.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                tvLocalUrlValue.text = formatMdnsUrl(s?.toString() ?: "")
+                tvLocalUrlValue.text = formatMdnsUrl(s?.toString() ?: "", currentTab)
                 if (cbAllowExternal.isChecked) {
-                    val qrUrl = getQrTargetUrl()
+                    val qrUrl = getEndpointTargetUrl(currentTab)
                     val qrBmp = HamClockNative.generateQRCodeBitmap(qrUrl, scale = 5, border = 2)
                     ivLocalAccessQr.setImageBitmap(qrBmp)
-                    tvQrCodeLabel.text = getString(R.string.scan_qr_to_open_ip, qrUrl)
+                    tvQrCodeLabel.text = getString(R.string.scan_qr_to_open)
+                    tvQrUrlValue.text = qrUrl
                     updateMdnsService(true, s?.toString()?.trim())
                 }
             }
@@ -320,8 +366,7 @@ class MainActivity : AppCompatActivity() {
         })
 
         btnCopyLocalUrl.setOnClickListener {
-            val ip = getDeviceIpAddress()
-            val copyUrl = if (!ip.isNullOrEmpty()) "http://$ip:$RW_PORT/live.html" else tvLocalUrlValue.text.toString()
+            val copyUrl = getEndpointTargetUrl(currentTab)
             val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
             val clip = ClipData.newPlainText("HamClock URL", copyUrl)
             clipboard?.setPrimaryClip(clip)
@@ -355,7 +400,7 @@ class MainActivity : AppCompatActivity() {
         val tvRestPortConflict = dialogView.findViewById<TextView>(R.id.tv_rest_port_conflict)
 
         val restText = if (actualRestPort > 0) "Port $actualRestPort" else getString(R.string.rest_port_disabled)
-        tvPortsInfo.text = getString(R.string.server_ports_format, RW_PORT, RO_PORT, restText)
+        tvPortsInfo.text = getString(R.string.server_ports_compact, RW_PORT, RO_PORT, restText)
 
         if (restPortConflict) {
             tvRestPortConflict.visibility = View.VISIBLE
@@ -380,8 +425,9 @@ class MainActivity : AppCompatActivity() {
                 val newStartOnBoot = cbStartOnBoot.isChecked
                 val newAllowExternal = cbAllowExternal.isChecked
                 val newMdnsName = etMdnsName.text.toString().trim()
+                val newRunInBackground = cbRunInBackground.isChecked
 
-                Log.i(TAG, "Saving settings: backend=$newHost, startOnBoot=$newStartOnBoot, allowExternal=$newAllowExternal, mdnsName=$newMdnsName")
+                Log.i(TAG, "Saving settings: backend=$newHost, startOnBoot=$newStartOnBoot, allowExternal=$newAllowExternal, mdnsName=$newMdnsName, runInBackground=$newRunInBackground")
                 val hostChanged = newHost != currentHost
 
                 prefs.edit()
@@ -389,6 +435,7 @@ class MainActivity : AppCompatActivity() {
                     .putBoolean(PREF_START_ON_BOOT, newStartOnBoot)
                     .putBoolean(PREF_ALLOW_EXTERNAL, newAllowExternal)
                     .putString(PREF_MDNS_NAME, newMdnsName)
+                    .putBoolean(PREF_RUN_IN_BACKGROUND, newRunInBackground)
                     .commit()
 
                 HamClockNative.setAllowExternalAccess(newAllowExternal)
@@ -434,6 +481,7 @@ class MainActivity : AppCompatActivity() {
         val btnExitApp = dialogView.findViewById<Button>(R.id.btn_exit_app)
         btnExitApp?.setOnClickListener {
             Log.i(TAG, "User requested Exit HamClock from settings dialog")
+            isExplicitExit = true
             dialog.dismiss()
             finishAndRemoveTask()
         }
@@ -1121,12 +1169,30 @@ class MainActivity : AppCompatActivity() {
         return super.onKeyLongPress(keyCode, event)
     }
 
+    override fun onBackPressed() {
+        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val runInBackground = prefs.getBoolean(PREF_RUN_IN_BACKGROUND, false)
+        if (runInBackground) {
+            Log.i(TAG, "Run in background enabled - moving task to back on Back press")
+            moveTaskToBack(true)
+        } else {
+            super.onBackPressed()
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
+        val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val runInBackground = prefs.getBoolean(PREF_RUN_IN_BACKGROUND, false)
         HamClockNative.setAppControlListener(null)
-        unregisterMdnsService()
-        releaseWifiLock()
-        executor.shutdown()
-        android.os.Process.killProcess(android.os.Process.myPid())
+
+        if (isExplicitExit || !runInBackground) {
+            unregisterMdnsService()
+            releaseWifiLock()
+            executor.shutdown()
+            android.os.Process.killProcess(android.os.Process.myPid())
+        } else {
+            Log.i(TAG, "MainActivity destroyed with run_in_background=true; keeping daemon active in background")
+        }
     }
 }

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -1071,24 +1071,16 @@ class MainActivity : AppCompatActivity() {
                 return true
             }
 
-            // If settings button is currently focused on the main screen
+            // If settings button is explicitly focused
             if (btnSettings.isFocused) {
                 when (event.keyCode) {
                     KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
                         btnSettings.performClick()
                         return true
                     }
-                    KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_BACK -> {
+                    KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.KEYCODE_BACK -> {
                         btnSettings.clearFocus()
                         webView.requestFocus()
-                        return true
-                    }
-                }
-            } else {
-                // If settings button is NOT focused, navigate to it on Down or Right
-                when (event.keyCode) {
-                    KeyEvent.KEYCODE_DPAD_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                        btnSettings.requestFocus()
                         return true
                     }
                 }

--- a/android/app/src/main/res/drawable/edit_text_background.xml
+++ b/android/app/src/main/res/drawable/edit_text_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#26FFFFFF" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#3DFFFFFF" />
+            <stroke android:width="1dp" android:color="@color/hamclock_accent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#1AFFFFFF" />
+            <stroke android:width="1dp" android:color="#4DFFFFFF" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/layout/dialog_backend_settings.xml
+++ b/android/app/src/main/res/layout/dialog_backend_settings.xml
@@ -140,8 +140,11 @@
                 android:textColor="@color/hamclock_text"
                 android:textColorHint="#888888"
                 android:focusable="true"
-                android:padding="8dp"
-                android:background="@drawable/item_focus_highlight" />
+                android:paddingStart="10dp"
+                android:paddingEnd="10dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:background="@drawable/edit_text_background" />
 
             <!-- Endpoint Switcher Tabs: Live Clock vs Antennas -->
             <LinearLayout
@@ -306,8 +309,11 @@
         android:textColor="@color/hamclock_text"
         android:textColorHint="#888888"
         android:focusable="true"
-        android:padding="8dp"
-        android:background="@drawable/item_focus_highlight" />
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:background="@drawable/edit_text_background" />
 
     <View
         android:layout_width="match_parent"

--- a/android/app/src/main/res/layout/dialog_backend_settings.xml
+++ b/android/app/src/main/res/layout/dialog_backend_settings.xml
@@ -143,13 +143,48 @@
                 android:padding="8dp"
                 android:background="@drawable/item_focus_highlight" />
 
+            <!-- Endpoint Switcher Tabs: Live Clock vs Antennas -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:focusable="false"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="4dp">
+
+                <Button
+                    android:id="@+id/btn_tab_live"
+                    android:layout_width="0dp"
+                    android:layout_height="32dp"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="3dp"
+                    android:text="@string/endpoint_live_clock"
+                    android:textColor="@color/hamclock_text"
+                    android:textSize="11sp"
+                    android:background="@drawable/btn_setup_selector"
+                    android:focusable="true" />
+
+                <Button
+                    android:id="@+id/btn_tab_antennas"
+                    android:layout_width="0dp"
+                    android:layout_height="32dp"
+                    android:layout_weight="1"
+                    android:layout_marginStart="3dp"
+                    android:text="@string/endpoint_antennas"
+                    android:textColor="@color/hamclock_text"
+                    android:textSize="11sp"
+                    android:background="@drawable/btn_neutral_selector"
+                    android:focusable="true" />
+            </LinearLayout>
+
             <TextView
+                android:id="@+id/tv_local_url_label"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/local_url_label"
                 android:textColor="@color/hamclock_text"
-                android:textSize="12sp"
-                android:layout_marginTop="8dp" />
+                android:textSize="11sp"
+                android:layout_marginTop="4dp" />
 
             <TextView
                 android:id="@+id/tv_local_url_value"
@@ -159,9 +194,9 @@
                 android:textColor="#80D8FF"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
-                android:textSize="13sp"
+                android:textSize="12sp"
                 android:layout_marginTop="2dp"
-                android:layout_marginBottom="8dp" />
+                android:layout_marginBottom="6dp" />
 
             <Button
                 android:id="@+id/btn_copy_local_url"
@@ -171,12 +206,32 @@
                 android:textColor="@color/hamclock_text"
                 android:textSize="12sp"
                 android:background="@drawable/btn_neutral_selector"
-                android:focusable="true" />
+                android:focusable="true"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:id="@+id/tv_ports_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="#AAAAAA"
+                android:textSize="11sp"
+                android:lineSpacingExtra="2dp"
+                android:layout_marginTop="2dp" />
+
+            <TextView
+                android:id="@+id/tv_rest_port_conflict"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/rest_port_conflict_warning"
+                android:textColor="#FFB74D"
+                android:textSize="11sp"
+                android:layout_marginTop="2dp"
+                android:visibility="gone" />
         </LinearLayout>
 
         <LinearLayout
             android:id="@+id/ll_qr_code_container"
-            android:layout_width="wrap_content"
+            android:layout_width="140dp"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
@@ -184,18 +239,18 @@
 
             <TextView
                 android:id="@+id/tv_qr_code_label"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/scan_qr_to_open"
                 android:textColor="@color/hamclock_text"
                 android:textSize="11sp"
-                android:gravity="center_horizontal"
+                android:gravity="center"
                 android:layout_marginBottom="6dp" />
 
             <FrameLayout
                 android:id="@+id/fl_qr_code_frame"
-                android:layout_width="140dp"
-                android:layout_height="140dp"
+                android:layout_width="130dp"
+                android:layout_height="130dp"
                 android:background="@drawable/item_focus_highlight"
                 android:focusable="true"
                 android:clickable="true"
@@ -210,6 +265,17 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter" />
             </FrameLayout>
+
+            <TextView
+                android:id="@+id/tv_qr_url_value"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="#80D8FF"
+                android:textSize="10sp"
+                android:gravity="center"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:layout_marginTop="4dp" />
         </LinearLayout>
     </LinearLayout>
 
@@ -303,31 +369,29 @@
         android:layout_marginBottom="12dp"
         android:background="#33FFFFFF" />
 
-    <TextView
+    <CheckBox
+        android:id="@+id/cb_run_in_background"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/server_ports_label"
+        android:text="@string/run_in_background_label"
         android:textColor="@color/hamclock_text"
-        android:textSize="14sp" />
+        android:textSize="14sp"
+        android:buttonTint="@color/hamclock_accent"
+        android:focusable="true"
+        android:clickable="true"
+        android:padding="8dp"
+        android:background="@drawable/item_focus_highlight" />
 
     <TextView
-        android:id="@+id/tv_ports_info"
+        android:id="@+id/tv_run_in_background_subtext"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="#80D8FF"
-        android:textSize="13sp"
-        android:lineSpacingExtra="3dp"
-        android:layout_marginTop="3dp" />
-
-    <TextView
-        android:id="@+id/tv_rest_port_conflict"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/rest_port_conflict_warning"
-        android:textColor="#FFB74D"
-        android:textSize="12sp"
-        android:layout_marginTop="3dp"
-        android:visibility="gone" />
+        android:text="@string/run_in_background_subtext"
+        android:textColor="#888888"
+        android:textSize="11sp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="-4dp"
+        android:layout_marginBottom="8dp" />
 
 </LinearLayout>
 </ScrollView>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -27,9 +27,9 @@
     <string name="local_url_label">Access from browser on your local network:</string>
     <string name="copy_url">Copy URL</string>
     <string name="copied_to_clipboard">Copied URL to clipboard</string>
-    <string name="scan_qr_to_open">Scan with phone or tablet to open:</string>
-    <string name="scan_qr_to_open_ip">Scan with phone/tablet to open:\n%1$s</string>
+    <string name="scan_qr_to_open">Scan with phone/tablet to open:</string>
     <string name="server_ports_label">Server Ports:</string>
+    <string name="server_ports_compact">Ports: Web %1$d (R/W), %2$d (R/O)  •  REST: %3$s</string>
     <string name="server_ports_format">Live Web (R/W): %1$d   •   Live Web (R/O): %2$d\nRESTful API: %3$s</string>
     <string name="rest_port_label">RESTful API Port:</string>
     <string name="rest_port_active">Port %1$d</string>
@@ -38,6 +38,11 @@
     <string name="rest_port_conflict_disabled">⚠️ Port 8080 was in use by another app. REST API is disabled.</string>
     <string name="rest_port_conflict_toast">Notice: Port 8080 is in use by another app. REST API switched to port %1$d.</string>
     <string name="rest_port_disabled_toast">Notice: Port 8080 is in use by another app. REST API has been disabled.</string>
+    <string name="endpoint_live_clock">Live Clock (:8081)</string>
+    <string name="endpoint_antennas">Antennas (:8080)</string>
+    <string name="antenna_url_label">Antenna configuration page:</string>
+    <string name="run_in_background_label">Keep HamClock running in the background</string>
+    <string name="run_in_background_subtext">Keep engine, live web, and antenna servers active when navigating away or pressing Back</string>
 </resources>
 
 


### PR DESCRIPTION
## Summary
This PR enhances the Android Settings dialog:
- **Antenna QR Code & URL Switcher**: Added in-place segmented tab switcher to easily view and scan the `/antennas.html` configuration page (:8080) alongside Live Clock (:8081).
- **Run in Background Option**: Added a checkbox (defaults to off) to keep HamClock engine and web servers active in the background when navigating away or pressing Back.
- **Layout Decluttering**:
  - Moved server ports and port conflict warnings up into the Local LAN Access card beneath the Copy URL button.
  - Removed redundant `IP:` line from local hostname display.
  - Reorganized QR section with header prompt above and direct IP URL centered below QR code.

## Verification
- Tested and verified on **Amazon Fire TV Stick** (via D-Pad remote navigation) and **Pixel Tablet** (touch screen).
- All unit tests and release builds pass cleanly.
