### PR TITLE
Prevent DE and DX clocks from painting over active menus

### DIFF
--- a/ESPHamClock/ESPHamClock.cpp
+++ b/ESPHamClock/ESPHamClock.cpp
@@ -2113,8 +2113,13 @@ void drawDEFormatMenu()
     // run menu
     SBox ok_b;
     MenuInfo menu = {menu_b, ok_b, UF_CLOCKSOK, M_CANCELOK, 1, NARRAY(mitems), mitems};
-    if (!runMenu (menu))
+    if (!runMenu (menu)) {
+        if (!SHOWING_PANE_0()) {
+            drawDEInfo();
+            drawDXInfo();
+        }
         return;
+    }
 
     if (mitems[0].set) {
 

--- a/ESPHamClock/HamClock.h
+++ b/ESPHamClock/HamClock.h
@@ -893,6 +893,7 @@ extern void drawTZ (TZInfo &tzi);
 extern bool inBox (const SCoord &s, const SBox &b);
 extern bool inCircle (const SCoord &s, const SCircle &c);
 extern bool boxesOverlap (const SBox &b1, const SBox &b2);
+extern bool menuOverlaps (const SBox &box);
 extern void doReboot (bool minus_K, bool minus_0);
 extern void printFreeHeap (const __FlashStringHelper *label);
 extern void getWorstMem (int *heap, int *stack);

--- a/ESPHamClock/clocks.cpp
+++ b/ESPHamClock/clocks.cpp
@@ -1121,30 +1121,32 @@ void updateClocks(bool all)
     if (draw_other_times && !SHOWING_PANE_0()) {
 
         // DE pane
-        switch (de_time_fmt) {
-        case DETIME_CAL:
-            drawDECalTime(true);
-            drawCalendar(false);
-            break;
-        case DETIME_ANALOG:     // fallthru
-        case DETIME_ANALOG_DTTM:
-            drawAnalogClock (t_utc + getTZ (de_tz));
-            break;
-        case DETIME_INFO:
-            drawDECalTime(false);
-            drawDESunRiseSetInfo();
-            break;
-        case DETIME_DIGITAL_12: // fallthru
-        case DETIME_DIGITAL_24: // fallthru
-            drawDigitalClock (t_utc + getTZ (de_tz));
-            break;
-        default:
-            fatalError ("unknown de fmt %d", de_time_fmt);
-            break;
+        if (!menuOverlaps (de_info_b)) {
+            switch (de_time_fmt) {
+            case DETIME_CAL:
+                drawDECalTime(true);
+                drawCalendar(false);
+                break;
+            case DETIME_ANALOG:     // fallthru
+            case DETIME_ANALOG_DTTM:
+                drawAnalogClock (t_utc + getTZ (de_tz));
+                break;
+            case DETIME_INFO:
+                drawDECalTime(false);
+                drawDESunRiseSetInfo();
+                break;
+            case DETIME_DIGITAL_12: // fallthru
+            case DETIME_DIGITAL_24: // fallthru
+                drawDigitalClock (t_utc + getTZ (de_tz));
+                break;
+            default:
+                fatalError ("unknown de fmt %d", de_time_fmt);
+                break;
+            }
         }
 
         // DX pane
-        if (!dx_info_for_sat) {
+        if (!dx_info_for_sat && !menuOverlaps (dx_info_b)) {
             drawDXTime();
             drawDXSunRiseSetInfo();
         }

--- a/ESPHamClock/menu.cpp
+++ b/ESPHamClock/menu.cpp
@@ -680,6 +680,15 @@ static bool menuStateOk (MenuInfo &menu)
     return (true);
 }
 
+static const SBox *active_menu_box;
+
+/* return whether the currently active menu overlaps the given box
+ */
+bool menuOverlaps (const SBox &box)
+{
+    return active_menu_box != nullptr && boxesOverlap (*active_menu_box, box);
+}
+
 /* operate the given menu until ok, cancel or timeout.
  * caller passes a box we use for ok so they can use it later with menuRedrawOk if needed.
  * return true if op clicked ok or CR/NL else false for all other cases.
@@ -781,6 +790,8 @@ bool runMenu (MenuInfo &menu)
     }
 
     // menu_b is now properly positioned
+    const SBox *prev_menu_box = active_menu_box;
+    active_menu_box = &menu.menu_b;
 
     // capture what we are about to clobber
     uint8_t *backing_store;
@@ -961,6 +972,8 @@ bool runMenu (MenuInfo &menu)
         if (MENU_ACTIVE(mi.type))
             Serial.printf ("  %-15s g%d s%d\n", mi.label ? mi.label : "", mi.group, mi.set);
     }
+
+    active_menu_box = prev_menu_box;
 
     return (ok);
 }


### PR DESCRIPTION
### Summary
Fixes an issue introduced in v4.30b05.0 (#319) where minute rollovers caused the DE and DX clocks to redraw and paint over the active DE format / Pane 0 popup menu.

### Changes
1. **Track active menu bounds**:
   - Track `active_menu_box` in `menu.cpp` during `runMenu()`.
   - Expose `menuOverlaps(const SBox &box)` to check whether an on-screen box intersects an active menu.
2. **Prevent clock painting over menus**:
   - In `clocks.cpp`'s `updateClocks()`, guard DE and DX clock drawing with `!menuOverlaps(de_info_b)` and `!menuOverlaps(dx_info_b)`.
   - Allows the main clock in the upper left (`clock_b`) to continue running and ticking seconds/minutes while keeping the DE/DX menu clean.
3. **Keep clocks active and sync on menu close**:
   - Keep `UF_CLOCKSOK` in `drawDEFormatMenu()` so the main clock does not freeze.
   - If the menu is dismissed or cancelled, immediately refresh DE and DX info (`drawDEInfo()` / `drawDXInfo()`) so the displayed time reflects any minute rollovers that occurred while the menu was open.