### PR TITLE
Improve Android settings button contrast and reduce footprint

### DIFF
--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -113,9 +113,9 @@ class MainActivity : AppCompatActivity() {
         btnSettings.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
                 btnSettings.alpha = 1.0f
-                btnSettings.animate().scaleX(1.25f).scaleY(1.25f).setDuration(150).start()
+                btnSettings.animate().scaleX(1.15f).scaleY(1.15f).setDuration(150).start()
             } else {
-                btnSettings.alpha = 0.6f
+                btnSettings.alpha = 0.8f
                 btnSettings.animate().scaleX(1.0f).scaleY(1.0f).setDuration(150).start()
             }
         }

--- a/android/app/src/main/res/drawable/btn_settings_focus.xml
+++ b/android/app/src/main/res/drawable/btn_settings_focus.xml
@@ -2,18 +2,20 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_focused="true">
         <shape android:shape="oval">
-            <solid android:color="#4D00E5FF" />
-            <stroke android:width="3dp" android:color="@color/hamclock_accent" />
+            <solid android:color="#E61A1A1A" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
         </shape>
     </item>
     <item android:state_pressed="true">
         <shape android:shape="oval">
-            <solid android:color="#8000E5FF" />
+            <solid android:color="#CC333333" />
+            <stroke android:width="2dp" android:color="@color/hamclock_accent" />
         </shape>
     </item>
     <item>
         <shape android:shape="oval">
-            <solid android:color="@android:color/transparent" />
+            <solid android:color="#B3000000" />
+            <stroke android:width="1dp" android:color="#80FFFFFF" />
         </shape>
     </item>
 </selector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -39,17 +39,19 @@
 
     <ImageButton
         android:id="@+id/btn_settings"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
         android:layout_gravity="bottom|end"
-        android:layout_margin="12dp"
+        android:layout_margin="10dp"
+        android:padding="6dp"
+        android:scaleType="fitCenter"
         android:background="@drawable/btn_settings_focus"
         android:focusable="true"
         android:focusableInTouchMode="false"
         android:contentDescription="@string/settings_title"
         android:src="@android:drawable/ic_menu_preferences"
         app:tint="@color/white"
-        android:alpha="0.6" />
+        android:alpha="0.8" />
 
 </FrameLayout>
 


### PR DESCRIPTION
## Summary
- **High-contrast container**: Added a dark translucent circular badge (`#B3000000`) with a light stroke (`#80FFFFFF`) to the settings button drawable so the white tool icon remains crisp and clearly visible across all map types, including bright white cloud layers and dark night terminators.
- **Dark backing on focus/press**: Preserved a dark base in focused and pressed states so the green accent outline remains contrast-safe over light backgrounds.
- **Reduced footprint**: Scaled down the button from 48dp to 32dp with 6dp internal padding, significantly reducing screen clutter while preserving an easy touch and D-pad target.
- **Subtler TV animation**: Adjusted resting alpha to 0.8 and D-pad focus scaling to 1.15x (down from 1.25x).

## Verification
- Built debug APK and verified via Gradle.
- Deployed and verified on Amazon Fire TV (via D-pad remote navigation).
- Deployed and verified on Android tablet.