### PR TITLE
Scope virtual remote cursor to Fire TV and restore web menu navigation

### DIFF
--- a/ESPHamClock/liveweb-html.cpp
+++ b/ESPHamClock/liveweb-html.cpp
@@ -413,20 +413,6 @@ char live_html[] =  R"_raw_html_(
         // send the given key and optionl control and shift modifier codes to the hamclock
         function sendKey (k, c, s) {
 
-            // handle D-pad arrow keys for virtual remote cursor
-            if (k === 'ArrowUp' || k === 'ArrowDown' || k === 'ArrowLeft' || k === 'ArrowRight') {
-                handleVirtualCursorMove (k);
-                return;
-            }
-
-            // handle Enter / Select for virtual remote cursor
-            if (k === 'Enter') {
-                if (vcursor_visible || (window.AndroidApp && window.AndroidApp.setEmbedVisible)) {
-                    handleVirtualCursorClick();
-                    return;
-                }
-            }
-
             // a real space would send 'char= ' which doesn't parse so we invent Space name
             if (k === ' ')
                 k = 'Space';

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -1134,27 +1134,53 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-            when (event.keyCode) {
-                KeyEvent.KEYCODE_DPAD_UP -> {
-                    webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowUp');", null)
-                    return true
+            if (isFireTvOrTv()) {
+                when (event.keyCode) {
+                    KeyEvent.KEYCODE_DPAD_UP -> {
+                        webView.evaluateJavascript("if (typeof handleVirtualCursorMove === 'function') handleVirtualCursorMove('ArrowUp');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        webView.evaluateJavascript("if (typeof handleVirtualCursorMove === 'function') handleVirtualCursorMove('ArrowDown');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                        webView.evaluateJavascript("if (typeof handleVirtualCursorMove === 'function') handleVirtualCursorMove('ArrowLeft');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                        webView.evaluateJavascript("if (typeof handleVirtualCursorMove === 'function') handleVirtualCursorMove('ArrowRight');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                        event.startTracking()
+                        webView.evaluateJavascript("if (typeof handleVirtualCursorClick === 'function') handleVirtualCursorClick();", null)
+                        return true
+                    }
                 }
-                KeyEvent.KEYCODE_DPAD_DOWN -> {
-                    webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowDown');", null)
-                    return true
-                }
-                KeyEvent.KEYCODE_DPAD_LEFT -> {
-                    webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowLeft');", null)
-                    return true
-                }
-                KeyEvent.KEYCODE_DPAD_RIGHT -> {
-                    webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowRight');", null)
-                    return true
-                }
-                KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
-                    event.startTracking()
-                    webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('Enter');", null)
-                    return true
+            } else {
+                when (event.keyCode) {
+                    KeyEvent.KEYCODE_DPAD_UP -> {
+                        webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowUp');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_DOWN -> {
+                        webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowDown');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_LEFT -> {
+                        webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowLeft');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                        webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('ArrowRight');", null)
+                        return true
+                    }
+                    KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                        event.startTracking()
+                        webView.evaluateJavascript("if (typeof sendKey === 'function') sendKey('Enter');", null)
+                        return true
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **Restored `sendKey()` for web clients**: Removed the virtual cursor interception of Arrow keys and Enter from `sendKey()` in `liveweb-html.cpp`. Normal web browsers (desktop, Docker, laptops) now send arrow keys and Enter directly to the HamClock backend via WebSocket for standard menu navigation rather than moving the virtual pointer.
- **Scoped virtual pointer to TV**: Updated `MainActivity.kt` to evaluate `isFireTvOrTv()` before routing D-pad events. On Fire TV / Android TV, D-pad events continue calling `handleVirtualCursorMove()` and `handleVirtualCursorClick()` as needed for Amazon certification. On non-TV Android devices (e.g. tablets), D-pad events fall back to `sendKey()`.

## Verification
- Verified compilation of C++ `liveweb-html.cpp` and Android sources via Gradle.
- Deployed and verified on physical Amazon Fire TV Stick.
- Deployed and verified on physical Android tablet.