### PR TITLE
Fix Amazon LWA scope URL encoding and resolve Kotlin build warnings

### DIFF
--- a/.github/scripts/upload_amazon_appstore.py
+++ b/.github/scripts/upload_amazon_appstore.py
@@ -25,7 +25,7 @@ def get_lwa_token(client_id: str, client_secret: str) -> str:
         "client_id": client_id,
         "client_secret": client_secret,
         "scope": "appstore::apps:readwrite",
-    }).encode("utf-8")
+    }, safe=":").encode("utf-8")
 
     req = urllib.request.Request(
         LWA_TOKEN_URL,

--- a/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
+++ b/android/app/src/main/java/org/openhamclock/hamclock/MainActivity.kt
@@ -486,9 +486,8 @@ class MainActivity : AppCompatActivity() {
             finishAndRemoveTask()
         }
 
-        var autoDismissRunnable: Runnable? = null
         if (isFirstRunTv) {
-            autoDismissRunnable = object : Runnable {
+            val autoDismissRunnable = object : Runnable {
                 override fun run() {
                     if (dialog.isShowing) {
                         if (isCallsignSet()) {
@@ -1195,6 +1194,7 @@ class MainActivity : AppCompatActivity() {
         return super.onKeyLongPress(keyCode, event)
     }
 
+    @Suppress("DEPRECATION")
     override fun onBackPressed() {
         val prefs = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val runInBackground = prefs.getBoolean(PREF_RUN_IN_BACKGROUND, false)


### PR DESCRIPTION
## Summary
- **Amazon LWA Scope URL Encoding**: Added `safe=':'` to `urllib.parse.urlencode()` in `.github/scripts/upload_amazon_appstore.py` to preserve literal colons in `scope=appstore::apps:readwrite`. Previously, Python encoded colons as `%3A`, which caused Amazon's Login with Amazon (LWA) token endpoint to reject the request with an `invalid_scope` error.
- **Kotlin Warnings**:
  - Fixed the `autoDismissRunnable` redundant initializer compiler warning in `MainActivity.kt`.
  - Added `@Suppress("DEPRECATION")` to `onBackPressed()` in `MainActivity.kt` to eliminate the deprecated Java method compiler warning.

## Verification
- Verified `./gradlew compileDebugKotlin` completes with 0 warnings.
- Verified payload formatting with Python `urllib.parse.urlencode` with `safe=':'`.